### PR TITLE
Minor update

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Time will be use in "!time" command and
 
 **Note on How to get DISCORD_WEBHOOK_X_URL** - See this: https://gyazo.com/539739f0bab50636e20a0fb76e9f1720 (settings in your respective channels)
 #### Queue alert
-- `DISABLE_DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT`: [true|false] - Same as `DISABLE_SOMETHING_WROMG_ALERT`, but if set to `false`, it will be sent to Discord Webhook instead of Steam Chat.
+- `DISABLE_DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT`: [true|false] - Same as `DISABLE_SOMETHING_WROMG_ALERT`, but if set to `true`, it will send to your Steam Chat.
 - `DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT_URL` - Discord Webhook URL for SOMETHING_WROMG_ALERT.
 
 #### Pricelist update
@@ -274,7 +274,7 @@ Time will be use in "!time" command and
 - `DISCORD_WEBHOOK_PRICE_UPDATE_ADDITIONAL_DESCRIPTION_NOTE` - You can add note there, or just leave it empty.
 
 #### Successful trade summary
-- `DISABLE_DISCORD_WEBHOOK_TRADE_SUMMARY`: [true|false] - Display every successful trade summary on your trade summary/live-trades channel. If set to `false`, it will send to your Steam Chat.
+- `DISABLE_DISCORD_WEBHOOK_TRADE_SUMMARY`: [true|false] - Display every successful trade summary on your trade summary/live-trades channel. If set to `true`, it will send to your Steam Chat.
 - `DISCORD_WEBHOOK_TRADE_SUMMARY_URL` - Discord Webhook URL for TRADE_SUMMARY.
 - `DISCORD_WEBHOOK_TRADE_SUMMARY_SHOW_QUICK_LINKS`: [true|false] - Show trade partner quick links to their Steam profile, backpack.tf and SteamREP pages.
 - `DISCORD_WEBHOOK_TRADE_SUMMARY_SHOW_KEY_RATE`: [true|false] - self explained.
@@ -288,7 +288,7 @@ Time will be use in "!time" command and
 ![trade-summary-full2](https://user-images.githubusercontent.com/47635037/86468438-0073e600-bd6a-11ea-8bc0-040229c997d5.PNG)
 
 #### Offer review summary
-- `DISABLE_DISCORD_WEBHOOK_OFFER_REVIEW`: [true|false] - Used to alert you on the trade that needs for offer review via Discord Webhook. If set to false, it will send to your Steam Chat.
+- `DISABLE_DISCORD_WEBHOOK_OFFER_REVIEW`: [true|false] - Used to alert you on the trade that needs for offer review via Discord Webhook. If set to `true`, it will send to your Steam Chat.
 - `DISCORD_WEBHOOK_REVIEW_OFFER_URL` - Discord Webhook URL for REVIEW_OFFER.
 - `DISCORD_WEBHOOK_REVIEW_OFFER_SHOW_QUICK_LINKS`: [true|false] - Show trade partner quick links to their Steam profile, backpack.tf and SteamREP pages.
 - `DISCORD_WEBHOOK_REVIEW_OFFER_DISABLE_MENTION_INVALID_VALUE`: [true|false] - Set to `true` if you want your bot to not mention on only INVALID_VALUE offer.
@@ -298,7 +298,7 @@ Time will be use in "!time" command and
 ![only non-invalid-value2](https://user-images.githubusercontent.com/47635037/86468430-feaa2280-bd69-11ea-8f25-26a7a430b2e1.PNG)
 
 #### Messages
-- `DISABLE_DISCORD_WEBHOOK_MESSAGE_FROM_PARTNER`: [true|false] - Used to alert you on any messages sent from trade partner. If set to `false`, it will send to your Steam Chat.
+- `DISABLE_DISCORD_WEBHOOK_MESSAGE_FROM_PARTNER`: [true|false] - Used to alert you on any messages sent from trade partner. If set to `true`, it will send to your Steam Chat.
 - `DISCORD_WEBHOOK_MESSAGE_FROM_PARTNER_URL` - Discord Webhook URL for MESSAGE_FROM_PARTNER.
 - `DISCORD_WEBHOOK_MESSAGE_FROM_PARTNER_SHOW_QUICK_LINKS`: [true|false] - Show trade partner quick links to their Steam profile, backpack.tf and SteamREP pages.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Some screenshots:
 
 ![autokeys3](https://user-images.githubusercontent.com/47635037/84581310-9c1cd100-ae12-11ea-80fa-085ad8bff73e.png)
 
-You can see codes on how this feature works [here](https://github.com/idinium96/tf2autobot/blob/master/src/classes/MyHandler.ts#L1481-L1991).
+You can see codes on how this feature works [here](https://github.com/idinium96/tf2autobot/blob/master/src/classes/MyHandler.ts#L1509-L2006).
 
 ### Emojis and more commands added
 
@@ -156,8 +156,8 @@ Let say you want to trade an unusual OR an australium, which the value as we kno
 ### Your bot credentials
 - `STEAM_ACCOUNT_NAME`: username that is used to login (preferably your bot/alt Steam account).
 - `STEAM_PASSWORD`: your bot Steam account password.
-- `STEAM_SHARED_SECRET`: you can found this in `<Your Bot SteamID64>.maFile` inside ~/SDA/maFiles (named `shared_secret`).
-- `STEAM_IDENTITY_SECRET`: same as above (named `identity_secret`).
+- `STEAM_SHARED_SECRET`: you can found this in `<Your Bot SteamID64>.maFile` file inside ~/SDA/maFiles folder. Open the file using notepad and search for `"shared_secret": "agdgwegdgawfagxafagfkagusbuigiuefh=="` <-- take only this one (which is `agdgwegdgawfagxafagfkagusbuigiuefh==` in this example. Do not use this one).
+- `STEAM_IDENTITY_SECRET`: same as above (but now search for `identity_secret`).
 
 ### Prices.TF token
 - `PRICESTF_API_TOKEN`: You can leave this empty. No need at all.
@@ -168,7 +168,7 @@ You can run your bot without this first, which then on the first run, it will pr
 - `BPTF_API_KEY`: https://backpack.tf/developer/apikey/view - fill in site URL (`http://localhost:4566/tasks`) and comments (`Check if a user is banned on backpack.tf`).
 
 ### Your bot settings
-- `AUTOBUMP`: If you don't have backpack.tf premium, then your bot will re-list all listings every 30 minutes.
+- `AUTOBUMP`: [true|false] Default is `true`. If you don't have backpack.tf premium, then your bot will re-list all listings every 30 minutes.
 
 - `MINIMUM_SCRAP`: [Number] Default is 9 scraps. If it has less, it will smelt reclaimed metal so your bot will have more than minimum scraps.
 - `MINIMUM_RECLAIMED`: [Number] Default is 9 Reclaimed. Explained above.
@@ -185,7 +185,7 @@ You can run your bot without this first, which then on the first run, it will pr
 **This feature is meant to make your bot to have enough pure in their inventory. Enabling Autokeys - Banking might cause your bot to not function as intended.
 
 #### Set to true if want to disable
-- `DISABLE_INVENTORY_SORT`: [true|false] Default: `true`. Sort your bot inventory.
+- `DISABLE_INVENTORY_SORT`: [true|false] Default: `false`. Sort your bot inventory.
 - `DISABLE_LISTINGS`: [true|false] Default: `false`. This is used if you want to temporarily disable trading while your bot is alive.
 - `DISABLE_CRAFTING`: [true|false] Default: `false`. **NOT RECOMMENDED** to set is as `true`, as it cause bot and trade partner to not be able to trade because of missing pure changes.
 - `DISABLE_CRAFTING_WEAPONS`: [true|false] Default: `false`. Set to **`true` if you DO NOT** want your bot to automatically craft any duplicated craftable weapons.
@@ -305,7 +305,7 @@ Time will be use in "!time" command and
 ### Manual Review settings
 - `ENABLE_MANUAL_REVIEW`: [true|false] - Set to `true` if you want any INVALID_VALUE/INVALID_ITEMS/OVERSTOCKED/DUPED_ITEMS/DUPE_CHECK_FAILED trades to be reviewed by you.
 - `DISABLE_SHOW_REVIEW_OFFER_SUMMARY`: [true|false] - set to `true` if you do not want your bot to show offer summary to trade partner, but it will only notify trade partner that their offer is being hold for a review.
-- `DISABLE_REVIEW_OFFER_NOTE`: [true|false] - If set to `false`, it will show note on [each error](https://github.com/idinium96/tf2autobot/blob/master/src/classes/MyHandler.ts#L1278-L1478)
+- `DISABLE_REVIEW_OFFER_NOTE`: [true|false] - If set to `false`, it will show note on [each error](https://github.com/idinium96/tf2autobot/blob/master/src/classes/MyHandler.ts#L1312-L1500)
 - `DISABLE_SHOW_CURRENT_TIME`: [true|false] - If set to `false`, it will show owner time on offer review notification that trade partner will received.
 
 - `DISABLE_ACCEPT_INVALID_ITEMS_OVERPAY`: [true|false] - Default: `false`. Set to `true` if you do not want your bot to accept a trade with INVALID_ITEMS but with their value more or equal to our value.

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,15 +75,35 @@
             "dev": true
         },
         "@microsoft/tsdoc-config": {
-            "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.13.4.tgz",
-            "integrity": "sha512-B3F3mndJTGUmcHTt8chqjN4EPvxJlkzZIkrZUHwJvKvbr74HEe6mB8Aa6Rlh8jj6mHq7mmtyiUn17+5zr4vbXw==",
+            "version": "0.13.5",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.13.5.tgz",
+            "integrity": "sha512-KlnIdTRnPSsU9Coz9wzDAkT8JCLopP3ec1sgsgo7trwE6QLMKRpM4hZi2uzVX897SW49Q4f439auGBcQLnZQfA==",
             "dev": true,
             "requires": {
                 "@microsoft/tsdoc": "0.12.20",
-                "ajv": "~6.10.2",
+                "ajv": "~6.12.3",
                 "jju": "~1.4.0",
                 "resolve": "~1.12.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.3",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+                    "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+                    "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+                    "dev": true
+                }
             }
         },
         "@nicklason/request-retry": {
@@ -1863,13 +1883,13 @@
             }
         },
         "eslint-plugin-tsdoc": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.5.tgz",
-            "integrity": "sha512-KXquQlf/3u2U7A3LebYdcmAMtMxmUW3HN4JtOluq+iRuRPbBNVeUlg4SOXrnqSuQCOpSITHlPhP418IwjExA+w==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.6.tgz",
+            "integrity": "sha512-pU6/VVEOlC85BrUjsqZGGSRy41N+PHfWXokqjpQRWT1LSpBsAEbRpsueNYSFS+93Sx9CFD0511kjLKVySRbLbg==",
             "dev": true,
             "requires": {
                 "@microsoft/tsdoc": "0.12.20",
-                "@microsoft/tsdoc-config": "0.13.4"
+                "@microsoft/tsdoc-config": "0.13.5"
             }
         },
         "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "eslint": "^6.8.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-prettier": "^3.1.4",
-        "eslint-plugin-tsdoc": "^0.2.5",
+        "eslint-plugin-tsdoc": "^0.2.6",
         "nodemon": "^2.0.4",
         "prettier": "^1.19.1",
         "typescript": "^3.9.7"

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -647,13 +647,11 @@ export = class Commands {
                 );
             } else {
                 this.bot.messageAdmins(
-                    `/quote 💬 You've got a message from #${steamID} (${adminDetails.player_name}):
-                    
-                    "${msg}".
-                    
-                    Steam: ${links.steamProfile}
-                    Backpack.tf: ${links.backpackTF}
-                    SteamREP: ${links.steamREP}`,
+                    `/quote 💬 You've got a message from #${steamID} (${adminDetails.player_name}):` +
+                        `"${msg}".` +
+                        `Steam: ${links.steamProfile}` +
+                        `Backpack.tf: ${links.backpackTF}` +
+                        `SteamREP: ${links.steamREP}`,
                     []
                 );
             }

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -19,7 +19,7 @@ import DiscordWebhook from './DiscordWebhook';
 import { Item, Currency } from '../types/TeamFortress2';
 import { UnknownDictionaryKnownValues, UnknownDictionary } from '../types/common';
 import { fixItem } from '../lib/items';
-import { requestCheck, getPrice } from '../lib/ptf-api';
+import { requestCheck, getPrice, getSales } from '../lib/ptf-api';
 import validator from '../lib/validator';
 import log from '../lib/logger';
 import SchemaManager from 'tf2-schema';
@@ -43,7 +43,8 @@ const COMMANDS: string[] = [
     '!clearcart - Clears the current cart ❎🛒',
     '!checkout - Make the bot send an offer the items in the cart ✅🛒',
     '!queue - See your position in the queue',
-    '!cancel - Cancel an already made offer, or cancel offer being made ❌'
+    '!cancel - Cancel an already made offer, or cancel offer being made ❌',
+    '!sales sku=<item sku> - get sales history for an item'
 ];
 
 const ADMIN_COMMANDS: string[] = [
@@ -150,6 +151,8 @@ export = class Commands {
             this.pricecheckCommand(steamID, message);
         } else if (command === 'check' && isAdmin) {
             this.checkCommand(steamID, message);
+        } else if (command === 'sales') {
+            this.getSalesCommand(steamID, message);
         } else if (command === 'delete' && isAdmin) {
             this.deleteCommand(steamID, message);
         } else if (command === 'expand' && isAdmin) {
@@ -1540,8 +1543,11 @@ export = class Commands {
         } catch (err) {
             this.bot.sendMessage(
                 steamID,
-                `Error getting price for ${name}: ${err.body && err.body.message ? err.body.message : err.message}`
+                `Error getting price for ${name === null ? params.sku : name}: ${
+                    err.body && err.body.message ? err.body.message : err.message
+                }`
             );
+            return;
         }
 
         if (!price) {
@@ -1554,6 +1560,106 @@ export = class Commands {
             steamID,
             `🔎 ${name}:\n• Buy  : ${currBuy}\n• Sell : ${currSell}\n\nPrices.TF: https://prices.tf/items/${params.sku}`
         );
+    }
+
+    private async getSalesCommand(steamID: SteamID, message: string): Promise<void> {
+        message = removeLinkProtocol(message);
+        const params = CommandParser.parseParams(CommandParser.removeCommand(message));
+
+        if (params.sku === undefined) {
+            const item = this.getItemFromParams(steamID, params);
+
+            if (item === null) {
+                return;
+            }
+
+            params.sku = SKU.fromObject(item);
+        }
+
+        params.sku = SKU.fromObject(fixItem(SKU.fromString(params.sku), this.bot.schema));
+        const item = SKU.fromString(params.sku);
+        const name = this.bot.schema.getName(item);
+
+        let salesData;
+
+        try {
+            salesData = await getSales(params.sku, 'bptf');
+        } catch (err) {
+            this.bot.sendMessage(
+                steamID,
+                `❌ Error getting sell snapshots for ${name === null ? params.sku : name}: ${
+                    err.body && err.body.message ? err.body.message : err.message
+                }`
+            );
+            return;
+        }
+
+        if (!salesData) {
+            this.bot.sendMessage(steamID, `❌ No recorded snapshots found for ${name === null ? params.sku : name}.`);
+            return;
+        }
+
+        if (salesData.sales.length === 0) {
+            this.bot.sendMessage(steamID, `❌ No recorded snapshots found for ${name === null ? params.sku : name}.`);
+            return;
+        }
+
+        const sales: {
+            seller: string;
+            itemHistory: string;
+            keys: number;
+            metal: number;
+            date: number;
+        }[] = [];
+
+        salesData.sales.forEach(sale => {
+            sales.push({
+                seller: 'https://backpack.tf/profiles/' + sale.steamid,
+                itemHistory: 'https://backpack.tf/item/' + sale.id.replace('440_', ''),
+                keys: sale.currencies.keys,
+                metal: sale.currencies.metal,
+                date: sale.time
+            });
+        });
+
+        sales.sort(function(a, b) {
+            return b.date - a.date;
+        });
+
+        let left = 0;
+        const SalesList: string[] = [];
+
+        for (let i = 0; i < sales.length; i++) {
+            if (SalesList.length > 40) {
+                left += 1;
+            } else {
+                SalesList.push(
+                    `Listed #${i + 1}-----` +
+                        '\n• Date: ' +
+                        moment
+                            .unix(sales[i].date)
+                            .utc()
+                            .toString() +
+                        '\n• Item: ' +
+                        sales[i].itemHistory +
+                        '\n• Seller: ' +
+                        sales[i].seller +
+                        '\n• Was selling for: ' +
+                        (sales[i].keys > 0 ? sales[i].keys + ' keys, ' : '') +
+                        sales[i].metal +
+                        ' ref'
+                );
+            }
+        }
+
+        let reply = `🔎 Prices.TF: tf2-automatic/tf2autobot bots' removed sell listings from backpack.tf\n\nItem name: ${
+            salesData.name
+        }\n\n-----${SalesList.join('\n\n-----')}`;
+        if (left > 0) {
+            reply += `,\n\nand ${left} other ${pluralize('sale', left)}`;
+        }
+
+        this.bot.sendMessage(steamID, reply);
     }
 
     private expandCommand(steamID: SteamID, message: string): void {

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -1884,7 +1884,7 @@ export = class Commands {
     private nameCommand(steamID: SteamID, message: string): void {
         const newName = CommandParser.removeCommand(message);
 
-        if (newName === '') {
+        if (!newName || newName === '') {
             this.bot.sendMessage(steamID, '❌ You forgot to add a name. Example: "!name IdiNium"');
             return;
         }
@@ -1908,7 +1908,7 @@ export = class Commands {
     private avatarCommand(steamID: SteamID, message: string): void {
         const imageUrl = CommandParser.removeCommand(message);
 
-        if (imageUrl === '') {
+        if (!imageUrl || imageUrl === '') {
             this.bot.sendMessage(
                 steamID,
                 '❌ You forgot to add an image url. Example: "!avatar https://steamuserimages-a.akamaihd.net/ugc/949595415286366323/8FECE47652C9D77501035833E937584E30D0F5E7/"'
@@ -1938,7 +1938,7 @@ export = class Commands {
     private blockCommand(steamID: SteamID, message: string): void {
         const steamid = CommandParser.removeCommand(message);
 
-        if (steamid === '') {
+        if (!steamid || steamid === '') {
             this.bot.sendMessage(steamID, '❌ You forgot to add their SteamID64. Example: 76561198798404909');
             return;
         }
@@ -1965,7 +1965,7 @@ export = class Commands {
     private unblockCommand(steamID: SteamID, message: string): void {
         const steamid = CommandParser.removeCommand(message);
 
-        if (steamid === '') {
+        if (!steamid || steamid === '') {
             this.bot.sendMessage(steamID, '❌ You forgot to add their SteamID64. Example: 76561198798404909');
             return;
         }

--- a/src/classes/DiscordWebhook.ts
+++ b/src/classes/DiscordWebhook.ts
@@ -335,7 +335,15 @@ export = class DiscordWebhook {
             });
         });
 
-        const isMentionInvalidItems = (this.bot.handler as MyHandler).getAcceptedWithInvalidItemsOrOverstockedStatus();
+        const theirItemsFiltered = theirItems.filter(sku => !['5021;6', '5000;6', '5001;6', '5002;6'].includes(sku));
+
+        if (process.env.DISABLE_CRAFTWEAPON_AS_CURRENCY === 'false') {
+            theirItemsFiltered.filter(sku => !(this.bot.handler as MyHandler).craftweapon().includes(sku));
+        }
+
+        const isMentionInvalidItems = theirItemsFiltered.some((sku: string) => {
+            return this.bot.pricelist.getPrice(sku, false) === null;
+        });
 
         const mentionOwner =
             this.enableMentionOwner === true && (isMentionOurItems || isMentionThierItems)
@@ -343,7 +351,7 @@ export = class DiscordWebhook {
                 : this.enableMentionOwner === true &&
                   process.env.DISABLE_ACCEPT_INVALID_ITEMS_OVERPAY === 'false' &&
                   isMentionInvalidItems
-                ? `<@!${this.ownerID}> - Accepted INVALID_ITEMS/OVERSTOCKED same value/overpay trade here!`
+                ? `<@!${this.ownerID}> - Accepted INVALID_ITEMS/OVERSTOCKED with same value/overpay trade here!`
                 : '';
 
         const botName = this.botName;

--- a/src/classes/DiscordWebhook.ts
+++ b/src/classes/DiscordWebhook.ts
@@ -351,7 +351,7 @@ export = class DiscordWebhook {
                 : this.enableMentionOwner === true &&
                   process.env.DISABLE_ACCEPT_INVALID_ITEMS_OVERPAY === 'false' &&
                   isMentionInvalidItems
-                ? `<@!${this.ownerID}> - Accepted INVALID_ITEMS with same value/overpay trade here!`
+                ? `<@!${this.ownerID}> - Accepted INVALID_ITEMS with overpay trade here!`
                 : '';
 
         const botName = this.botName;

--- a/src/classes/DiscordWebhook.ts
+++ b/src/classes/DiscordWebhook.ts
@@ -351,7 +351,7 @@ export = class DiscordWebhook {
                 : this.enableMentionOwner === true &&
                   process.env.DISABLE_ACCEPT_INVALID_ITEMS_OVERPAY === 'false' &&
                   isMentionInvalidItems
-                ? `<@!${this.ownerID}> - Accepted INVALID_ITEMS/OVERSTOCKED with same value/overpay trade here!`
+                ? `<@!${this.ownerID}> - Accepted INVALID_ITEMS with same value/overpay trade here!`
                 : '';
 
         const botName = this.botName;

--- a/src/classes/DiscordWebhook.ts
+++ b/src/classes/DiscordWebhook.ts
@@ -335,15 +335,7 @@ export = class DiscordWebhook {
             });
         });
 
-        const theirItemsFiltered = theirItems.filter(sku => !['5021;6', '5000;6', '5001;6', '5002;6'].includes(sku));
-
-        if (process.env.DISABLE_CRAFTWEAPON_AS_CURRENCY === 'false') {
-            theirItemsFiltered.filter(sku => !(this.bot.handler as MyHandler).craftweapon().includes(sku));
-        }
-
-        const isMentionInvalidItems = theirItemsFiltered.some((sku: string) => {
-            return this.bot.pricelist.getPrice(sku, false) === null;
-        });
+        const isMentionInvalidItems = (this.bot.handler as MyHandler).getAcceptedWithInvalidItemsOrOverstockedStatus();
 
         const mentionOwner =
             this.enableMentionOwner === true && (isMentionOurItems || isMentionThierItems)
@@ -351,7 +343,7 @@ export = class DiscordWebhook {
                 : this.enableMentionOwner === true &&
                   process.env.DISABLE_ACCEPT_INVALID_ITEMS_OVERPAY === 'false' &&
                   isMentionInvalidItems
-                ? `<@!${this.ownerID}> - Accepted INVALID_ITEMS with overpay trade here!`
+                ? `<@!${this.ownerID}> - Accepted INVALID_ITEMS/OVERSTOCKED with overpay trade here!`
                 : '';
 
         const botName = this.botName;

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -91,8 +91,6 @@ export = class MyHandler extends Handler {
 
     private hasInvalidValueException = false;
 
-    private isAcceptedWithInvalidItemsOrOverstocked = false;
-
     private customGameName: string;
 
     recentlySentMessage: UnknownDictionary<number> = {};
@@ -214,10 +212,6 @@ export = class MyHandler extends Handler {
 
     getMinimumKeysDupeCheck(): number {
         return this.minimumKeysDupeCheck;
-    }
-
-    getAcceptedWithInvalidItemsOrOverstockedStatus(): boolean {
-        return this.isAcceptedWithInvalidItemsOrOverstocked;
     }
 
     getAutokeysEnabled(): boolean {
@@ -1033,7 +1027,6 @@ export = class MyHandler extends Handler {
             }
         }
 
-        this.isAcceptedWithInvalidItemsOrOverstocked = false;
         if (wrongAboutOffer.length !== 0) {
             const reasons = wrongAboutOffer.map(wrong => wrong.reason);
             const uniqueReasons = reasons.filter(reason => reasons.includes(reason));
@@ -1070,7 +1063,6 @@ export = class MyHandler extends Handler {
                         this.bot.schema
                     )}`
                 );
-                this.isAcceptedWithInvalidItemsOrOverstocked = true;
                 return { action: 'accept', reason: 'VALID' };
             } else if (
                 // If only INVALID_VALUE and did not matched exception value, will just decline the trade.

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1455,50 +1455,44 @@ export = class MyHandler extends Handler {
             } else {
                 const offerMessage = offer.message;
                 this.bot.messageAdmins(
-                    `/pre ⚠️ Offer #${offer.id} from ${offer.partner} is waiting for review.
-                    Reason: ${meta.uniqueReasons.join(', ')}
-                    
-                    Offer Summary:
-                    ${offer.summarize(this.bot.schema)}${
-                        value.diff > 0
-                            ? `\n📈 Profit from overpay: ${value.diffRef} ref` +
-                              (value.diffRef >= keyPrice.sell.metal ? ` (${value.diffKey})` : '')
-                            : value.diff < 0
-                            ? `\n📉 Loss from underpay: ${value.diffRef} ref` +
-                              (value.diffRef >= keyPrice.sell.metal ? ` (${value.diffKey})` : '')
-                            : ''
-                    }${offerMessage.length !== 0 ? `\n\n💬 Offer message: "${offerMessage}"` : ''}${
-                        invalidItemsName.length !== 0 ? `\n\n🟨INVALID_ITEMS - ${invalidItemsName.join(', ')}` : ''
-                    }${
-                        invalidItemsName.length !== 0 && overstockedItemsName.length !== 0
-                            ? `\n🟦OVERSTOCKED - ${overstockedItemsName.join(', ')}`
-                            : overstockedItemsName.length !== 0
-                            ? `\n\n🟦OVERSTOCKED - ${overstockedItemsName.join(', ')}`
-                            : ''
-                    }${
-                        (invalidItemsName.length !== 0 || overstockedItemsName.length !== 0) &&
-                        dupedItemsName.length !== 0
-                            ? `\n🟫DUPED_ITEMS - ${dupedItemsName.join(', ')}`
-                            : dupedItemsName.length !== 0
-                            ? `\n\n🟫DUPED_ITEMS - ${dupedItemsName.join(', ')}`
-                            : ''
-                    }${
-                        (invalidItemsName.length !== 0 ||
-                            overstockedItemsName.length !== 0 ||
-                            dupedItemsName.length !== 0) &&
-                        dupedFailedItemsName.length !== 0
-                            ? `\n🟪DUPE_CHECK_FAILED - ${dupedFailedItemsName.join(', ')}`
-                            : dupedFailedItemsName.length !== 0
-                            ? `\n\n🟪DUPE_CHECK_FAILED - ${dupedFailedItemsName.join(', ')}`
-                            : ''
-                    }
-                    
-                    Steam: ${links.steamProfile}
-                    Backpack.tf: ${links.backpackTF}
-                    SteamREP: ${links.steamREP}
-
-                    🔑 Key rate: ${keyPrice.buy.metal.toString()}/${keyPrice.sell.metal.toString()} ref
-                    💰 Pure stock: ${pureStock.join(', ').toString()}`,
+                    `/pre ⚠️ Offer #${offer.id} from ${offer.partner} is waiting for review.` +
+                        `\nReason: ${meta.uniqueReasons.join(', ')}` +
+                        `\n\nOffer Summary: ${offer.summarize(this.bot.schema)}${
+                            value.diff > 0
+                                ? `\n📈 Profit from overpay: ${value.diffRef} ref` +
+                                  (value.diffRef >= keyPrice.sell.metal ? ` (${value.diffKey})` : '')
+                                : value.diff < 0
+                                ? `\n📉 Loss from underpay: ${value.diffRef} ref` +
+                                  (value.diffRef >= keyPrice.sell.metal ? ` (${value.diffKey})` : '')
+                                : ''
+                        }${offerMessage.length !== 0 ? `\n\n💬 Offer message: "${offerMessage}"` : ''}${
+                            invalidItemsName.length !== 0 ? `\n\n🟨INVALID_ITEMS - ${invalidItemsName.join(', ')}` : ''
+                        }${
+                            invalidItemsName.length !== 0 && overstockedItemsName.length !== 0
+                                ? `\n🟦OVERSTOCKED - ${overstockedItemsName.join(', ')}`
+                                : overstockedItemsName.length !== 0
+                                ? `\n\n🟦OVERSTOCKED - ${overstockedItemsName.join(', ')}`
+                                : ''
+                        }${
+                            (invalidItemsName.length !== 0 || overstockedItemsName.length !== 0) &&
+                            dupedItemsName.length !== 0
+                                ? `\n🟫DUPED_ITEMS - ${dupedItemsName.join(', ')}`
+                                : dupedItemsName.length !== 0
+                                ? `\n\n🟫DUPED_ITEMS - ${dupedItemsName.join(', ')}`
+                                : ''
+                        }${
+                            (invalidItemsName.length !== 0 ||
+                                overstockedItemsName.length !== 0 ||
+                                dupedItemsName.length !== 0) &&
+                            dupedFailedItemsName.length !== 0
+                                ? `\n🟪DUPE_CHECK_FAILED - ${dupedFailedItemsName.join(', ')}`
+                                : dupedFailedItemsName.length !== 0
+                                ? `\n\n🟪DUPE_CHECK_FAILED - ${dupedFailedItemsName.join(', ')}`
+                                : ''
+                        }` +
+                        `\n\nSteam: ${links.steamProfile}\nBackpack.tf: ${links.backpackTF}\nSteamREP: ${links.steamREP}` +
+                        `\n\n🔑 Key rate: ${keyPrice.buy.metal.toString()}/${keyPrice.sell.metal.toString()} ref` +
+                        `\n💰 Pure stock: ${pureStock.join(', ').toString()}`,
                     []
                 );
             }

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1055,7 +1055,7 @@ export = class MyHandler extends Handler {
                     uniqueReasons.includes('🟫DUPED_ITEMS') ||
                     uniqueReasons.includes('🟪DUPE_CHECK_FAILED')
                 ) &&
-                exchange.our.value <= exchange.their.value
+                exchange.our.value < exchange.their.value
             ) {
                 offer.log(
                     'trade',

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -93,6 +93,8 @@ export = class MyHandler extends Handler {
 
     private customGameName: string;
 
+    private isAcceptedWithInvalidItemsOrOverstocked = false;
+
     recentlySentMessage: UnknownDictionary<number> = {};
 
     constructor(bot: Bot) {
@@ -212,6 +214,10 @@ export = class MyHandler extends Handler {
 
     getMinimumKeysDupeCheck(): number {
         return this.minimumKeysDupeCheck;
+    }
+
+    getAcceptedWithInvalidItemsOrOverstockedStatus(): boolean {
+        return this.isAcceptedWithInvalidItemsOrOverstocked;
     }
 
     getAutokeysEnabled(): boolean {
@@ -1045,6 +1051,7 @@ export = class MyHandler extends Handler {
             //     const counteroffer = offer.counter();
             // }
 
+            this.isAcceptedWithInvalidItemsOrOverstocked = false;
             if (
                 ((uniqueReasons.includes('🟨INVALID_ITEMS') &&
                     process.env.DISABLE_ACCEPT_INVALID_ITEMS_OVERPAY !== 'true') ||
@@ -1057,6 +1064,7 @@ export = class MyHandler extends Handler {
                 ) &&
                 exchange.our.value < exchange.their.value
             ) {
+                this.isAcceptedWithInvalidItemsOrOverstocked = true;
                 offer.log(
                     'trade',
                     `contains invalid items/overstocked, but offer more or equal value, accepting. Summary:\n${offer.summarize(

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -130,11 +130,13 @@ export = class MyHandler extends Handler {
             this.invalidValueExceptionSKU = [';5;u', ';11;australium'];
         }
 
-        if (process.env.CUSTOM_PLAYING_GAME_NAME === 'tf2-automatic') {
-            this.customGameName = process.env.CUSTOM_PLAYING_GAME_NAME;
+        const customGameName = process.env.CUSTOM_PLAYING_GAME_NAME;
+
+        if (!customGameName || customGameName === 'tf2-automatic') {
+            this.customGameName = customGameName;
         } else {
-            if (process.env.CUSTOM_PLAYING_GAME_NAME.length <= 45) {
-                this.customGameName = process.env.CUSTOM_PLAYING_GAME_NAME + ' - tf2-automatic';
+            if (customGameName.length <= 45) {
+                this.customGameName = customGameName + ' - tf2-automatic';
             } else {
                 log.warn(
                     'Your custom game playing name is more than 45 characters, resetting to only "tf2-automatic"...'

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1031,6 +1031,7 @@ export = class MyHandler extends Handler {
             }
         }
 
+        this.isAcceptedWithInvalidItemsOrOverstocked = false;
         if (wrongAboutOffer.length !== 0) {
             const reasons = wrongAboutOffer.map(wrong => wrong.reason);
             const uniqueReasons = reasons.filter(reason => reasons.includes(reason));
@@ -1232,7 +1233,6 @@ export = class MyHandler extends Handler {
                         links,
                         timeWithEmojis.time
                     );
-                    this.isAcceptedWithInvalidItemsOrOverstocked = false;
                 } else {
                     this.bot.messageAdmins(
                         'trade',

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1256,8 +1256,8 @@ export = class MyHandler extends Handler {
                                             (isBankingKeys ? ' (banking)' : isBuyingKeys ? ' (buying)' : ' (selling)')
                                           : '🛑')
                                     : ''
-                            }
-                        💰 Pure stock: ${pureStock.join(', ').toString()}`,
+                            }` +
+                            `💰 Pure stock: ${pureStock.join(', ').toString()}`,
                         []
                     );
                 }

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -102,6 +102,8 @@ export default class Pricelist extends EventEmitter {
 
     private keyPrices: { buy: Currencies; sell: Currencies };
 
+    private oldPrice: Entry;
+
     constructor(schema: SchemaManager.Schema, socket: SocketIOClient.Socket) {
         super();
         this.schema = schema;
@@ -429,7 +431,7 @@ export default class Pricelist extends EventEmitter {
             };
         }
 
-        const oldPrice = this.getPrice(data.sku);
+        this.oldPrice = this.getPrice(data.sku);
         const match = this.getPrice(data.sku);
         if (match !== null && match.autoprice) {
             match.buy = new Currencies(data.buy);
@@ -444,7 +446,7 @@ export default class Pricelist extends EventEmitter {
                 process.env.DISABLE_DISCORD_WEBHOOK_PRICE_UPDATE === 'false' &&
                 process.env.DISCORD_WEBHOOK_PRICE_UPDATE_URL
             ) {
-                this.sendWebHookPriceUpdate(data.sku, itemName, match, oldPrice);
+                this.sendWebHookPriceUpdate(data.sku, itemName, match, this.oldPrice);
             }
         }
     }

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -102,8 +102,6 @@ export default class Pricelist extends EventEmitter {
 
     private keyPrices: { buy: Currencies; sell: Currencies };
 
-    private oldPrice: Entry[];
-
     constructor(schema: SchemaManager.Schema, socket: SocketIOClient.Socket) {
         super();
         this.schema = schema;
@@ -366,8 +364,6 @@ export default class Pricelist extends EventEmitter {
                 return;
             }
 
-            this.oldPrice = old;
-
             return this.updateOldPrices(old);
         });
     }
@@ -433,9 +429,6 @@ export default class Pricelist extends EventEmitter {
             };
         }
 
-        const oldPriceEntries = this.oldPrice.filter(entry => entry.sku === data.sku);
-        const oldPrice = oldPriceEntries[0];
-
         const match = this.getPrice(data.sku);
         if (match !== null && match.autoprice) {
             match.buy = new Currencies(data.buy);
@@ -450,7 +443,7 @@ export default class Pricelist extends EventEmitter {
                 process.env.DISABLE_DISCORD_WEBHOOK_PRICE_UPDATE === 'false' &&
                 process.env.DISCORD_WEBHOOK_PRICE_UPDATE_URL
             ) {
-                this.sendWebHookPriceUpdate(data.sku, itemName, match, oldPrice);
+                this.sendWebHookPriceUpdate(data.sku, itemName, match);
             }
         }
     }
@@ -460,7 +453,7 @@ export default class Pricelist extends EventEmitter {
         this.emit('pricelist', this.prices);
     }
 
-    private sendWebHookPriceUpdate(sku: string, itemName: string, newPrice: Entry, oldPrice: Entry): void {
+    private sendWebHookPriceUpdate(sku: string, itemName: string, newPrice: Entry): void {
         const request = new XMLHttpRequest();
         request.open('POST', process.env.DISCORD_WEBHOOK_PRICE_UPDATE_URL);
         request.setRequestHeader('Content-type', 'application/json');
@@ -639,7 +632,7 @@ export default class Pricelist extends EventEmitter {
                     },
                     title: '',
                     description:
-                        `**※Buying for:**\n${oldPrice.buy.toString()} → ${newPrice.buy.toString()}\n**※Selling for:**\n${oldPrice.sell.toString()} → ${newPrice.sell.toString()}\n` +
+                        `**※Buying for:** ${newPrice.buy.toString()}\n**※Selling for:** ${newPrice.sell.toString()}\n` +
                         (process.env.DISCORD_WEBHOOK_PRICE_UPDATE_ADDITIONAL_DESCRIPTION_NOTE
                             ? process.env.DISCORD_WEBHOOK_PRICE_UPDATE_ADDITIONAL_DESCRIPTION_NOTE
                             : ''),

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -429,6 +429,7 @@ export default class Pricelist extends EventEmitter {
             };
         }
 
+        const oldPrice = this.getPrice(data.sku);
         const match = this.getPrice(data.sku);
         if (match !== null && match.autoprice) {
             match.buy = new Currencies(data.buy);
@@ -443,7 +444,7 @@ export default class Pricelist extends EventEmitter {
                 process.env.DISABLE_DISCORD_WEBHOOK_PRICE_UPDATE === 'false' &&
                 process.env.DISCORD_WEBHOOK_PRICE_UPDATE_URL
             ) {
-                this.sendWebHookPriceUpdate(itemName, match.buy.toString(), match.sell.toString(), data.sku);
+                this.sendWebHookPriceUpdate(data.sku, itemName, match, oldPrice);
             }
         }
     }
@@ -453,7 +454,7 @@ export default class Pricelist extends EventEmitter {
         this.emit('pricelist', this.prices);
     }
 
-    private sendWebHookPriceUpdate(itemName: string, buyPrice: string, sellPrice: string, sku: string): void {
+    private sendWebHookPriceUpdate(sku: string, itemName: string, newPrice: Entry, oldPrice: Entry): void {
         const request = new XMLHttpRequest();
         request.open('POST', process.env.DISCORD_WEBHOOK_PRICE_UPDATE_URL);
         request.setRequestHeader('Content-type', 'application/json');
@@ -632,7 +633,7 @@ export default class Pricelist extends EventEmitter {
                     },
                     title: '',
                     description:
-                        `**※Buying for:** ${buyPrice}\n**※Selling for:** ${sellPrice}\n` +
+                        `**※Buying for:**\n${oldPrice.buy.toString()} → ${newPrice.buy.toString()}\n**※Selling for:**\n${oldPrice.sell.toString()} → ${newPrice.sell.toString()}\n` +
                         (process.env.DISCORD_WEBHOOK_PRICE_UPDATE_ADDITIONAL_DESCRIPTION_NOTE
                             ? process.env.DISCORD_WEBHOOK_PRICE_UPDATE_ADDITIONAL_DESCRIPTION_NOTE
                             : ''),

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -102,7 +102,7 @@ export default class Pricelist extends EventEmitter {
 
     private keyPrices: { buy: Currencies; sell: Currencies };
 
-    private oldPrice: Entry;
+    private oldPrice: Entry[];
 
     constructor(schema: SchemaManager.Schema, socket: SocketIOClient.Socket) {
         super();
@@ -366,6 +366,8 @@ export default class Pricelist extends EventEmitter {
                 return;
             }
 
+            this.oldPrice = old;
+
             return this.updateOldPrices(old);
         });
     }
@@ -431,7 +433,8 @@ export default class Pricelist extends EventEmitter {
             };
         }
 
-        this.oldPrice = this.getPrice(data.sku);
+        const oldPrice = this.oldPrice[data.sku];
+
         const match = this.getPrice(data.sku);
         if (match !== null && match.autoprice) {
             match.buy = new Currencies(data.buy);
@@ -446,7 +449,7 @@ export default class Pricelist extends EventEmitter {
                 process.env.DISABLE_DISCORD_WEBHOOK_PRICE_UPDATE === 'false' &&
                 process.env.DISCORD_WEBHOOK_PRICE_UPDATE_URL
             ) {
-                this.sendWebHookPriceUpdate(data.sku, itemName, match, this.oldPrice);
+                this.sendWebHookPriceUpdate(data.sku, itemName, match, oldPrice);
             }
         }
     }

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -433,7 +433,8 @@ export default class Pricelist extends EventEmitter {
             };
         }
 
-        const oldPrice = this.oldPrice[data.sku];
+        const oldPriceEntries = this.oldPrice.filter(entry => entry.sku === data.sku);
+        const oldPrice = oldPriceEntries[0];
 
         const match = this.getPrice(data.sku);
         if (match !== null && match.autoprice) {

--- a/src/lib/ptf-api.ts
+++ b/src/lib/ptf-api.ts
@@ -15,6 +15,10 @@ export function getPrice(sku: string, source: string): Promise<UnknownDictionary
     return apiRequest('GET', `/items/${sku}`, { src: source });
 }
 
+export function getSales(sku: string, source: string): Promise<UnknownDictionary<any>> {
+    return apiRequest('GET', `/items/${sku}/sales`, { src: source });
+}
+
 export function requestCheck(sku: string, source: string): Promise<UnknownDictionary<any>> {
     return apiRequest('POST', `/items/${sku}`, { source: source });
 }
@@ -24,7 +28,7 @@ function apiRequest(httpMethod: string, path: string, input: UnknownDictionary<a
         method: httpMethod,
         url: `https://api.prices.tf${path}`,
         headers: {
-            'User-Agent': 'tf2-automatic@' + process.env.BOT_VERSION
+            'User-Agent': 'tf2autobot@' + process.env.BOT_VERSION
         },
         json: true,
         gzip: true,


### PR DESCRIPTION
**added**
- `!sales` command - Gets a list of listings that have been removed (removed, is like it means that item has been sold with that price, but it is not so accurate since more and more bot owner now auto-restart their bot(s)). (6c89635)

**fixed**
- bot crashed when `CUSTOM_PLAYING_GAME_NAME` does not exist in your ecosystem.json file. (56a143d)
- bot crashed when using `!block <steamID>` and `!unblock <steamID>`, if the owner forgot to put targeted `<steamID>` in it. (d644875)
- weird review offer messages when using Steam Chat.

**changed**
- For auto-accept INVALID_ITEMS/OVERSTOCKED, it is now only accepted if overpaid (equal value or not same will be sent for a review).