### PR TITLE
update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tf2autobot
 
 A free and open source fully automated TF2 trading bot advertising on www.backpack.tf using prices from www.prices.tf.
-**tf2autobot** is an improved version of the original **tf2-automatic** made by [Nicklason](https://github.com/Nicklason). You can find out more about the original repository [here](https://github.com/Nicklason/tf2-automatic).
+**tf2autobot** is an improved and feature rich version of the original **tf2-automatic** made by [Nicklason](https://github.com/Nicklason). You can find out more about the original repository [here](https://github.com/Nicklason/tf2-automatic).
 
 ![GitHub package version](https://img.shields.io/github/package-json/v/idinium96/tf2autobot.svg)
 [![Build Status](https://img.shields.io/github/workflow/status/idinium96/tf2autobot/CI/development)](https://github.com/idinium96/tf2autobot/actions)
@@ -75,7 +75,7 @@ The original tf2-automatic repository already have a lot of features, but some f
 - automatically restart your bot on queue problem, and automatically relist if backpack.tf does not synchronized with your bot listings on Autokeys (sometimes it's set to automatically buy keys, but at backpack.tf, it's listed to sell.)
 - use emojis on almost all messages
 - list out every items on each offer review reasons
-- New added commands: "!pure", "!time", "!delete", "!check", "!block", "!unblock", "!autokeys", "!craftweapon" and "!uncraftweapon" commands
+- New added commands: "!pure", "!time", "!delete", "!check", "!block", "!unblock", "!autokeys", "!inventory", "!craftweapon" and "!uncraftweapon" commands
 - and more to come!
 
 ## Added features
@@ -143,7 +143,7 @@ Some screenshots:
 
 ![autokeys3](https://user-images.githubusercontent.com/47635037/84581310-9c1cd100-ae12-11ea-80fa-085ad8bff73e.png)
 
-You can see codes on how this feature works [here](https://github.com/idinium96/tf2autobot/blob/master/src/classes/MyHandler.ts#L1546-L2140).
+You can see codes on how this feature works [here](https://github.com/idinium96/tf2autobot/blob/master/src/classes/MyHandler.ts#L1582-L2176).
 
 ### Emojis and more commands added
 
@@ -294,7 +294,7 @@ Time will be use in "!time" command and
 - `DISCORD_WEBHOOK_TRADE_SUMMARY_SHOW_QUICK_LINKS`: [true|false] - Show trade partner quick links to their Steam profile, backpack.tf and SteamREP pages.
 - `DISCORD_WEBHOOK_TRADE_SUMMARY_SHOW_KEY_RATE`: [true|false] - self explained.
 - `DISCORD_WEBHOOK_TRADE_SUMMARY_SHOW_PURE_STOCK`: [true|false] - self explained.
-- `DISCORD_WEBHOOK_TRADE_SUMMARY_SHOW_INVENTORY`: [true|false] - Show total current items in your bot inventory (I have tried to include `/max slot` but it's not working).
+- `DISCORD_WEBHOOK_TRADE_SUMMARY_SHOW_INVENTORY`: [true|false] - Show total current items in your bot inventory.
 - `DISCORD_WEBHOOK_TRADE_SUMMARY_ADDITIONAL_DESCRIPTION_NOTE` - Notes.
 - `DISCORD_WEBHOOK_TRADE_SUMMARY_MENTION_OWNER` [true|false] - Set it to `true` if you want your bot to mention on every successful trades.
 - `DISCORD_WEBHOOK_TRADE_SUMMARY_MENTION_OWNER_ONLY_ITEMS_SKU` [StringArray] - Support multiple items sku, let say you want to be mentioned on every unusual and australium trades, just do `[";5;u", ";11;australium"]`, or if you want to mention on specific item, just fill in the full item sku like `["725;6;uncraftable"]`, then to add more, just separate it with a comma between each sku string.
@@ -321,7 +321,7 @@ Time will be use in "!time" command and
 ### Manual Review settings
 - `ENABLE_MANUAL_REVIEW`: [true|false] - Set to `true` if you want any INVALID_VALUE/INVALID_ITEMS/OVERSTOCKED/DUPED_ITEMS/DUPE_CHECK_FAILED trades to be reviewed by you.
 - `DISABLE_SHOW_REVIEW_OFFER_SUMMARY`: [true|false] - set to `true` if you do not want your bot to show offer summary to trade partner, but it will only notify trade partner that their offer is being hold for a review.
-- `DISABLE_REVIEW_OFFER_NOTE`: [true|false] - If set to `false`, it will show note on [each error](https://github.com/idinium96/tf2autobot/blob/master/src/classes/MyHandler.ts#L1340-L1471)
+- `DISABLE_REVIEW_OFFER_NOTE`: [true|false] - If set to `false`, it will show note on [each error](https://github.com/idinium96/tf2autobot/blob/master/src/classes/MyHandler.ts#L1358-L1572)
 - `DISABLE_SHOW_CURRENT_TIME`: [true|false] - If set to `false`, it will show owner time on offer review notification that trade partner will received.
 
 - `DISABLE_ACCEPT_INVALID_ITEMS_OVERPAY`: [true|false] - Default: `false`. Set to `true` if you do not want your bot to accept a trade with INVALID_ITEMS but with their value more or equal to our value.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The original tf2-automatic repository already have a lot of features, but some f
 - automatically restart your bot on queue problem, and automatically relist if backpack.tf does not synchronized with your bot listings on Autokeys (sometimes it's set to automatically buy keys, but at backpack.tf, it's listed to sell.)
 - use emojis on almost all messages
 - list out every items on each offer review reasons
-- New added commands: "!pure", "!time", "!delete", "!check", "!block", "!unblock", "!autokeys", "!inventory", "!craftweapon" and "!uncraftweapon" commands
+- New added commands: "!pure", "!time", "!delete", "!check", "!block", "!unblock", "!autokeys", "!inventory", "!adjustrate", "!craftweapon" and "!uncraftweapon" commands
 - and more to come!
 
 ## Added features

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -52,6 +52,7 @@ const ADMIN_COMMANDS: string[] = [
     '!withdraw <name=>&<amount=> - Used to withdraw items',
     '!add - Add a pricelist entry ➕',
     '!update - Update a pricelist entry',
+    '!adjustrate buy.metal=<buying price>&sell.metal=<selling price> - Manually adjust key rate (reset on restart, self-update when key rate changes)',
     '!remove <sku=> OR <item=> - Remove a pricelist entry ➖',
     '!get <sku=> OR <item=> - Get raw information about a pricelist entry',
     '!pricecheck <sku=> OR <item=> - Requests an item to be priced by PricesTF',
@@ -126,6 +127,8 @@ export = class Commands {
             this.uncraftweaponCommand(steamID);
         } else if (command === 'rate') {
             this.rateCommand(steamID);
+        } else if (command === 'adjustrate' && isAdmin) {
+            this.adjustKeyRateCommand(steamID, message);
         } else if (command === 'message') {
             this.messageCommand(steamID, message);
         } else if (command === 'cart') {
@@ -531,6 +534,32 @@ export = class Commands {
                 keyPrice +
                 ' is the same as one key.'
         );
+    }
+
+    private adjustKeyRateCommand(steamID: SteamID, message: string): void {
+        const params = CommandParser.parseParams(CommandParser.removeCommand(message));
+
+        if (!params || (params.buy === undefined && params.sell === undefined)) {
+            this.bot.sendMessage(
+                steamID,
+                '❌ You must include both buy AND sell price, example - "!adjustkeyrate sell.metal=56.33&buy.metal=56.22"'
+            );
+            return;
+        }
+
+        if (+params.buy.metal > +params.sell.metal) {
+            this.bot.sendMessage(steamID, '❌ Sell price must be higher than buy price.');
+            return;
+        }
+
+        const buyKeys = +params.buy.keys || 0;
+        const buyMetal = +params.buy.metal || 0;
+        const sellKeys = +params.sell.keys || 0;
+        const sellMetal = +params.sell.metal || 0;
+        const buy = { keys: buyKeys, metal: buyMetal };
+        const sell = { keys: sellKeys, metal: sellMetal };
+
+        this.bot.pricelist.adjustKeyRate(buy, sell);
     }
 
     private messageCommand(steamID: SteamID, message: string): void {

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -501,11 +501,17 @@ export = class Commands {
                     ? 'Banking' + (autokeys.scrapAdjustmentEnabled ? ' (default price)' : '')
                     : autokeys.isBuying
                     ? 'Buying for ' +
-                      Currencies.toRefined(keyPrices.buy.toValue() + autokeys.scrapAdjustmentValue).toString() +
+                      Currencies.toRefined(
+                          keyPrices.buy.toValue() +
+                              (autokeys.scrapAdjustmentEnabled ? autokeys.scrapAdjustmentValue : 0)
+                      ) +
                       ' ref' +
                       (autokeys.scrapAdjustmentEnabled ? ' (+' + autokeys.scrapAdjustmentValue + ' scrap)' : '')
                     : 'Selling for ' +
-                      Currencies.toRefined(keyPrices.sell.toValue() - autokeys.scrapAdjustmentValue).toString() +
+                      Currencies.toRefined(
+                          keyPrices.sell.toValue() -
+                              (autokeys.scrapAdjustmentEnabled ? autokeys.scrapAdjustmentValue : 0)
+                      ) +
                       ' ref' +
                       (autokeys.scrapAdjustmentEnabled ? ' (-' + autokeys.scrapAdjustmentValue + ' scrap)' : '')
                 : 'Not active'

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -422,7 +422,12 @@ export = class Commands {
 
     private inventoryCommand(steamID: SteamID): void {
         const currentItems = this.bot.inventoryManager.getInventory().getTotalItems();
-        this.bot.sendMessage(steamID, `🎒 My crrent items in my inventory: ${currentItems}`);
+        const backpackSlots = (this.bot.handler as MyHandler).getBackpackSlots();
+
+        this.bot.sendMessage(
+            steamID,
+            `🎒 My crrent items in my inventory: ${currentItems + (backpackSlots !== 0 ? '/' + backpackSlots : '')}`
+        );
     }
 
     private autoKeysCommand(steamID: SteamID): void {

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -560,6 +560,8 @@ export = class Commands {
         const sell = { keys: sellKeys, metal: sellMetal };
 
         this.bot.pricelist.adjustKeyRate(buy, sell);
+
+        this.bot.sendMessage(steamID, '✅ Key rate adjusted to ' + new Currencies(buy) + '/' + new Currencies(sell));
     }
 
     private messageCommand(steamID: SteamID, message: string): void {

--- a/src/classes/DiscordWebhook.ts
+++ b/src/classes/DiscordWebhook.ts
@@ -321,6 +321,7 @@ export = class DiscordWebhook {
         tradeSummary: string,
         pureStock: string[],
         currentItems: number,
+        backpackSlots: number,
         invalidItemsCombine: string[],
         keyPrice: { buy: Currencies; sell: Currencies },
         value: { diff: number; diffRef: number; diffKey: string },
@@ -483,7 +484,9 @@ export = class DiscordWebhook {
                                   }`
                                 : '') +
                             (isShowPureStock ? `\n💰 Pure stock: ${pureStock.join(', ').toString()}` : '') +
-                            (isShowInventory ? `\n🎒 Total items: ${currentItems}` : '') +
+                            (isShowInventory
+                                ? `\n🎒 Total items: ${currentItems + (backpackSlots !== 0 ? '/' + backpackSlots : '')}`
+                                : '') +
                             (AdditionalNotes ? '\n' + AdditionalNotes : ''),
                         color: botEmbedColor
                     }

--- a/src/classes/DiscordWebhook.ts
+++ b/src/classes/DiscordWebhook.ts
@@ -158,6 +158,7 @@ export = class DiscordWebhook {
     sendOfferReview(
         offer: TradeOffer,
         reason: string,
+        reasons: string,
         pureStock: string[],
         time: string,
         tradeSummary: string,
@@ -177,12 +178,12 @@ export = class DiscordWebhook {
         let noMentionOnInvalidValue = false;
         if (process.env.DISCORD_WEBHOOK_REVIEW_OFFER_DISABLE_MENTION_INVALID_VALUE !== 'false') {
             if (
-                reason.includes('🟥INVALID_VALUE') &&
+                reasons.includes('🟥INVALID_VALUE') &&
                 !(
-                    reason.includes('🟨INVALID_ITEMS') ||
-                    reason.includes('🟦OVERSTOCKED') ||
-                    reason.includes('🟫DUPED_ITEMS') ||
-                    reason.includes('🟪DUPE_CHECK_FAILED')
+                    reasons.includes('🟨INVALID_ITEMS') ||
+                    reasons.includes('🟦OVERSTOCKED') ||
+                    reasons.includes('🟫DUPED_ITEMS') ||
+                    reasons.includes('🟪DUPE_CHECK_FAILED')
                 )
             ) {
                 noMentionOnInvalidValue = true;
@@ -259,7 +260,13 @@ export = class DiscordWebhook {
                         },
                         title: '',
                         description:
-                            `⚠️ An offer sent by ${partnerNameNoFormat} is waiting for review.\nReason: ${reason}\n\n__Offer Summary__:\n` +
+                            `⚠️ An offer sent by ${partnerNameNoFormat} is waiting for review.\nReason: ${
+                                reason === '⬜BACKPACKTF_DOWN'
+                                    ? '⬜BACKPACKTF_DOWN - failed to check banned status'
+                                    : reason === '⬜STEAM_DOWN'
+                                    ? '⬜STEAM_DOWN - failed to check escrow status'
+                                    : reasons
+                            }\n\n__Offer Summary__:\n` +
                             tradeSummary.replace('Asked:', '**Asked:**').replace('Offered:', '**Offered:**') +
                             (value.diff > 0
                                 ? `\n📈 ***Profit from overpay:*** ${value.diffRef} ref` +

--- a/src/classes/Listings.ts
+++ b/src/classes/Listings.ts
@@ -22,6 +22,8 @@ export = class Listings {
 
     private autoRelistEnabled = false;
 
+    private autoRelistRetry = false;
+
     private autoRelistTimeout;
 
     private templates: { buy: string; sell: string } = {
@@ -97,6 +99,8 @@ export = class Listings {
         this.getAccountInfo().asCallback((err, info) => {
             if (err) {
                 log.warn('Failed to get account info from backpack.tf: ', err);
+                clearTimeout(this.autoRelistTimeout);
+                this.autoRelistRetry = true;
                 return;
             }
 
@@ -107,6 +111,9 @@ export = class Listings {
                 log.warn(
                     'Enabling autorelist! - Consider paying for backpack.tf premium instead of forcefully bumping listings: https://backpack.tf/donate'
                 );
+                this.enableAutoRelist();
+            } else if (this.autoRelistRetry) {
+                this.autoRelistRetry = false;
                 this.enableAutoRelist();
             }
         });

--- a/src/classes/Listings.ts
+++ b/src/classes/Listings.ts
@@ -24,6 +24,8 @@ export = class Listings {
 
     private autoRelistRetry = false;
 
+    private autoRelistRetryTimeout;
+
     private autoRelistTimeout;
 
     private templates: { buy: string; sell: string } = {
@@ -112,9 +114,13 @@ export = class Listings {
                     'Enabling autorelist! - Consider paying for backpack.tf premium instead of forcefully bumping listings: https://backpack.tf/donate'
                 );
                 this.enableAutoRelist();
-            } else if (this.autoRelistRetry) {
+            } else if (this.autoRelistEnabled && this.autoRelistRetry) {
                 this.autoRelistRetry = false;
-                this.enableAutoRelist();
+                clearTimeout(this.autoRelistRetryTimeout);
+                log.warn('backpack.tf down, will wait for 30 minutes before relist again...');
+                this.autoRelistRetryTimeout = setTimeout(() => {
+                    this.enableAutoRelist();
+                }, 30 * 60 * 1000);
             }
         });
     }

--- a/src/classes/Listings.ts
+++ b/src/classes/Listings.ts
@@ -122,7 +122,7 @@ export = class Listings {
                 log.warn('backpack.tf down, will wait for 30 minutes before relist again...');
                 this.autoRelistRetryTimeout = setTimeout(() => {
                     this.enableAutoRelist();
-                }, 30 * 60 * 1000);
+                }, 5 * 60 * 1000);
             }
         });
     }

--- a/src/classes/Listings.ts
+++ b/src/classes/Listings.ts
@@ -63,6 +63,7 @@ export = class Listings {
 
         this.autoRelistEnabled = true;
 
+        clearTimeout(this.autoRelistRetryTimeout);
         clearTimeout(this.autoRelistTimeout);
 
         const doneWait = (): void => {

--- a/src/classes/Listings.ts
+++ b/src/classes/Listings.ts
@@ -103,6 +103,7 @@ export = class Listings {
             if (err) {
                 log.warn('Failed to get account info from backpack.tf: ', err);
                 clearTimeout(this.autoRelistTimeout);
+                clearTimeout(this.autoRelistRetryTimeout);
                 this.autoRelistRetry = true;
                 return;
             }

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1035,6 +1035,13 @@ export = class MyHandler extends Handler {
         if (wrongAboutOffer.length !== 0) {
             const reasons = wrongAboutOffer.map(wrong => wrong.reason);
             const uniqueReasons = reasons.filter(reason => reasons.includes(reason));
+            const moreThanOnly =
+                (process.env.DISABLE_GIVE_PRICE_TO_INVALID_ITEMS === 'false' ||
+                    process.env.DISABLE_ACCEPT_OVERSTOCKED_OVERPAY === 'false') &&
+                exchange.our.value < exchange.their.value;
+            const moreThanOrEqualTo =
+                process.env.DISABLE_GIVE_PRICE_TO_INVALID_ITEMS === 'true' &&
+                exchange.our.value <= exchange.their.value;
 
             // TO DO: Counter offer?
             //
@@ -1053,13 +1060,13 @@ export = class MyHandler extends Handler {
                 ((uniqueReasons.includes('🟨INVALID_ITEMS') &&
                     process.env.DISABLE_ACCEPT_INVALID_ITEMS_OVERPAY !== 'true') ||
                     (uniqueReasons.includes('🟦OVERSTOCKED') &&
-                        !(process.env.DISABLE_ACCEPT_OVERSTOCKED_OVERPAY !== 'false'))) &&
+                        process.env.DISABLE_ACCEPT_OVERSTOCKED_OVERPAY !== 'true')) &&
                 !(
                     uniqueReasons.includes('🟥INVALID_VALUE') ||
                     uniqueReasons.includes('🟫DUPED_ITEMS') ||
                     uniqueReasons.includes('🟪DUPE_CHECK_FAILED')
                 ) &&
-                exchange.our.value < exchange.their.value &&
+                (moreThanOnly || moreThanOrEqualTo) &&
                 exchange.our.value !== 0
             ) {
                 this.isAcceptedWithInvalidItemsOrOverstocked = true;

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1137,6 +1137,15 @@ export = class MyHandler extends Handler {
                             ? process.env.CUSTOM_SUCCESS_MESSAGE
                             : '/pre ✅ Success! The offer went through successfully.'
                     );
+                } else if (offer.state === TradeOfferManager.ETradeOfferState.InEscrow) {
+                    this.bot.sendMessage(
+                        offer.partner,
+                        '✅ Success! The offer went through successfully, but you will receive your items after ~15 days.' +
+                            ' Please use Steam Guard Mobile Authenticator so you will no longer need to wait like this in the future.' +
+                            '\nRead:\n' +
+                            '• Steam Guard Mobile Authenticator - https://support.steampowered.com/kb_article.php?ref=8625-WRAH-9030' +
+                            '• Steam Guard: How to set up a Steam Guard Mobile Authenticator - https://support.steampowered.com/kb_article.php?ref=4440-RTUI-9218'
+                    );
                 } else if (offer.state === TradeOfferManager.ETradeOfferState.Declined) {
                     const offerReason: { reason: string } = offer.data('action');
                     const keyPrice = this.bot.pricelist.getKeyPrices();

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -344,8 +344,8 @@ export = class MyHandler extends Handler {
             }
 
             if (process.env.ENABLE_AUTO_SELL_AND_BUY_KEYS === 'true' && this.checkAutokeysStatus === true) {
-                log.debug('Disabling Autokeys...');
-                this.updateToDisableAutokeys();
+                log.debug('Disabling Autokeys and removing key from pricelist...');
+                this.removeAutoKeys();
             }
 
             this.bot.listings.removeAll().asCallback(function(err) {
@@ -1774,7 +1774,7 @@ Autokeys status:-
                 this.alreadyUpdatedToBank = false;
                 this.alreadyUpdatedToBuy = false;
                 this.alreadyUpdatedToSell = false;
-                this.updateToDisableAutokeys();
+                this.removeAutoKeys();
             } else if (isRemoveAutoKeys && !isEnableKeyBanking) {
                 // disable Autokeys when conditions to disable Autokeys matched
                 this.isBuyingKeys = false;
@@ -1784,7 +1784,7 @@ Autokeys status:-
                 this.alreadyUpdatedToBank = false;
                 this.alreadyUpdatedToBuy = false;
                 this.alreadyUpdatedToSell = false;
-                this.updateToDisableAutokeys();
+                this.removeAutoKeys();
             } else if (isAlertAdmins && isAlreadyAlert !== true) {
                 // alert admins when low pure
                 this.isBuyingKeys = false;

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -166,7 +166,7 @@ export = class MyHandler extends Handler {
             this.scrapAdjustmentValue = scrapValue;
         }
 
-        if (process.env.DISABLE_SCRAP_ADJUSTMENT === 'false') {
+        if (process.env.DISABLE_SCRAP_ADJUSTMENT !== 'true') {
             this.isUsingAutoPrice = false;
         }
 

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1035,13 +1035,14 @@ export = class MyHandler extends Handler {
         if (wrongAboutOffer.length !== 0) {
             const reasons = wrongAboutOffer.map(wrong => wrong.reason);
             const uniqueReasons = reasons.filter(reason => reasons.includes(reason));
-            const moreThanOnly =
-                (process.env.DISABLE_GIVE_PRICE_TO_INVALID_ITEMS === 'false' ||
-                    process.env.DISABLE_ACCEPT_OVERSTOCKED_OVERPAY === 'false') &&
-                exchange.our.value < exchange.their.value;
-            const moreThanOrEqualTo =
-                process.env.DISABLE_GIVE_PRICE_TO_INVALID_ITEMS === 'true' &&
-                exchange.our.value <= exchange.their.value;
+
+            const acceptingCondition =
+                process.env.DISABLE_GIVE_PRICE_TO_INVALID_ITEMS === 'false' ||
+                process.env.DISABLE_ACCEPT_OVERSTOCKED_OVERPAY === 'false'
+                    ? exchange.our.value < exchange.their.value
+                    : process.env.DISABLE_GIVE_PRICE_TO_INVALID_ITEMS === 'true'
+                    ? exchange.our.value <= exchange.their.value
+                    : false;
 
             // TO DO: Counter offer?
             //
@@ -1066,7 +1067,7 @@ export = class MyHandler extends Handler {
                     uniqueReasons.includes('🟫DUPED_ITEMS') ||
                     uniqueReasons.includes('🟪DUPE_CHECK_FAILED')
                 ) &&
-                (moreThanOnly || moreThanOrEqualTo) &&
+                acceptingCondition &&
                 exchange.our.value !== 0
             ) {
                 this.isAcceptedWithInvalidItemsOrOverstocked = true;

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -378,6 +378,21 @@ export default class Pricelist extends EventEmitter {
         });
     }
 
+    adjustKeyRate(buy: { keys: number; metal: number }, sell: { keys: number; metal: number }): void {
+        this.keyPrices = {
+            buy: new Currencies(buy),
+            sell: new Currencies(sell)
+        };
+        const entryKey = this.getPrice('5021;6');
+
+        if (entryKey !== null && entryKey.autoprice) {
+            // The price of a key in the pricelist can be different from keyPrices because the pricelist is not updated
+            entryKey.buy = new Currencies(buy);
+            entryKey.sell = new Currencies(sell);
+            entryKey.time = moment().valueOf();
+        }
+    }
+
     private updateOldPrices(old: Entry[]): Promise<void> {
         log.debug('Getting pricelist...');
 


### PR DESCRIPTION
**Fixes**
- possible fix for autobump (auto-relist) when backpack.tf down. (0ebdc0f, cb0dcca, 2b42957, c3fe87f, e987fce)
- possible fix when backpack.tf or Steam down - instead of ignoring the offer, it will be sent as review for owner to manually check partner backpack.tf banned status or Steam trading escrow status. (686f464)
- Autokeys command - display incorrect selling/buying price when scrap adjustment disabled. (52cb17f)

**Added**
- since IEconItems_440 API endpoint seems to have been fixed, the !inventory command and Discord Webhook trade summary now will show `current items/backpackSlots`. (74f73b1)
- accepted escrow trade message (b468015)
- `!adjustrate` command - manually adjust the current key rate. Example of usage: `!adjustrate buy.metal=56&sell.metal=56.11`. You must include both buy and sell price and sell price must be higher than the buy price. Note that adjusted key rate will not be saved and will be reset once you restart your bot OR new keyPrices is updated. (555536f, 01797da)

**Changed**
- if `DISABLE_GIVE_PRICE_TO_INVALID_ITEMS` or `DISABLE_ACCEPT_OVERSTOCKED_OVERPAY` set to `false` (enabled), it will accept trade offer that is only more than `(>)` our side value, and if `DISABLE_GIVE_PRICE_TO_INVALID_ITEMS` set to `true` (disabled), it will accept an offer that is more than or equal `(>=)` to our side value. (5db79c8)
- Autokeys: remove key from pricelist when not active or when shutting down the bot. (8e6641e)