### PR TITLE
update

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A free and open source fully automated TF2 trading bot advertising on www.backpa
 **tf2autobot made by IdiNium**
 [![profile-Steam](https://img.shields.io/badge/Steam-profile-blue)](https://steamcommunity.com/profiles/76561198013127982/)
 [![profile-bptf](https://img.shields.io/badge/Backpack.tf-profile-blue)](https://backpack.tf/profiles/76561198013127982)
-![profile](https://user-images.githubusercontent.com/47635037/88795331-708f5380-d1d2-11ea-8adf-92d94be581e9.PNG)
+[![profile](https://user-images.githubusercontent.com/47635037/88795331-708f5380-d1d2-11ea-8adf-92d94be581e9.PNG)](https://backpack.tf/profiles/76561198013127982)
 
 Before you install the bot, there are a few things you need to have taken care off before you will be able to run the bot.
 
@@ -147,7 +147,7 @@ Some screenshots:
 
 ![autokeys3](https://user-images.githubusercontent.com/47635037/84581310-9c1cd100-ae12-11ea-80fa-085ad8bff73e.png)
 
-You can see codes on how this feature works [here](https://github.com/idinium96/tf2autobot/blob/master/src/classes/MyHandler.ts#L1582-L2176).
+You can see codes on how this feature works [here](https://github.com/idinium96/tf2autobot/blob/master/src/classes/MyHandler.ts#L1636-L2304).
 
 ### Emojis and more commands added
 
@@ -356,7 +356,7 @@ Time will be use in "!time" command and
 
 -   `ENABLE_MANUAL_REVIEW`: [true|false] - Set to `true` if you want any INVALID_VALUE/INVALID_ITEMS/OVERSTOCKED/DUPED_ITEMS/DUPE_CHECK_FAILED trades to be reviewed by you.
 -   `DISABLE_SHOW_REVIEW_OFFER_SUMMARY`: [true|false] - set to `true` if you do not want your bot to show offer summary to trade partner, but it will only notify trade partner that their offer is being hold for a review.
--   `DISABLE_REVIEW_OFFER_NOTE`: [true|false] - If set to `false`, it will show note on [each error](https://github.com/idinium96/tf2autobot/blob/master/src/classes/MyHandler.ts#L1358-L1572)
+-   `DISABLE_REVIEW_OFFER_NOTE`: [true|false] - If set to `false`, it will show note on [each error](https://github.com/idinium96/tf2autobot/blob/master/src/classes/MyHandler.ts#L1414-L1634)
 -   `DISABLE_SHOW_CURRENT_TIME`: [true|false] - If set to `false`, it will show owner time on offer review notification that trade partner will received.
 
 -   `DISABLE_ACCEPT_INVALID_ITEMS_OVERPAY`: [true|false] - Default: `false`. Set to `true` if you do not want your bot to accept a trade with INVALID_ITEMS but with their value more or equal to our value.

--- a/src/classes/CartQueue.ts
+++ b/src/classes/CartQueue.ts
@@ -2,6 +2,8 @@ import SteamID from 'steamid';
 
 import Bot from './Bot';
 import Cart from './Cart';
+import DiscordWebhook from './DiscordWebhook';
+import MyHandler from './MyHandler';
 
 import log from '../lib/logger';
 
@@ -10,12 +12,17 @@ export = CartQueue;
 class CartQueue {
     private readonly bot: Bot;
 
+    readonly discord: DiscordWebhook;
+
     private carts: Cart[] = [];
 
     private busy = false;
 
+    private queuePositionCheck;
+
     constructor(bot: Bot) {
         this.bot = bot;
+        this.discord = new DiscordWebhook(bot);
     }
 
     enqueue(cart: Cart): number {
@@ -40,7 +47,54 @@ class CartQueue {
             this.handleQueue();
         });
 
+        clearTimeout(this.queuePositionCheck);
+        this.queueCheck();
+
         return position;
+    }
+
+    private queueCheck(): void {
+        log.debug(`Checking queue position in 5 minutes...`);
+        this.queuePositionCheck = setTimeout(() => {
+            const position = this.carts.length;
+            log.debug(`Current queue position: ${position + 1}`);
+            if (position >= 2) {
+                if (
+                    process.env.DISABLE_DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT === 'false' &&
+                    process.env.DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT_URL
+                ) {
+                    const time = (this.bot.handler as MyHandler).timeWithEmoji();
+                    this.discord.sendQueueAlert(position + 1, time.time);
+                    this.bot.botManager
+                        .restartProcess()
+                        .then(restarting => {
+                            if (!restarting) {
+                                this.discord.sendQueueAlertFailedPM2(time.time);
+                            }
+                        })
+                        .catch(err => {
+                            log.warn('Error occurred while trying to restart: ', err);
+                            this.discord.sendQueueAlertFailedError(err.message, time.time);
+                        });
+                } else {
+                    this.bot.messageAdmins(`⚠️ [Queue alert] Current position: ${position + 1}`, []);
+                    this.bot.botManager
+                        .restartProcess()
+                        .then(restarting => {
+                            if (!restarting) {
+                                this.bot.messageAdmins(
+                                    '❌ Automatic restart on queue problem failed because are not running the bot with PM2! See the documentation: https://github.com/idinium96/tf2autobot/wiki/e.-Running-with-PM2',
+                                    []
+                                );
+                            }
+                        })
+                        .catch(err => {
+                            log.warn('Error occurred while trying to restart: ', err);
+                            this.bot.messageAdmins(`❌ An error occurred while trying to restart: ${err.message}`, []);
+                        });
+                }
+            }
+        }, 5 * 60 * 1000);
     }
 
     dequeue(steamID: SteamID | string): boolean {

--- a/src/classes/CartQueue.ts
+++ b/src/classes/CartQueue.ts
@@ -113,6 +113,11 @@ class CartQueue {
         return true;
     }
 
+    resetQueue(): void {
+        log.debug('Queue reset initialized.');
+        this.carts.splice(0);
+    }
+
     getPosition(steamID: SteamID | string): number {
         const steamID64 = steamID.toString();
         return this.carts.findIndex(cart => cart.partner.toString() === steamID64);

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -1577,14 +1577,17 @@ export = class Commands {
 
         const total = pricelist.length;
         const totalTime = total * 2 * 1000;
+        const aSecond = 1 * 1000;
+        const aMin = 1 * 60 * 1000;
+        const anHour = 1 * 60 * 60 * 1000;
         this.bot.sendMessage(
             steamID,
             `⌛ Price check requested for ${total} items, will be done in approximately ${
-                totalTime < 1 * 60 * 1000
-                    ? `${Math.round(totalTime / 1000)} seconds.`
-                    : totalTime < 1 * 60 * 60 * 1000
-                    ? `${Math.round(totalTime / (1 * 60 * 1000))} minutes.`
-                    : `${Math.round(totalTime / (1 * 60 * 60 * 1000))} hours.`
+                totalTime < aMin
+                    ? `${Math.round(totalTime / aSecond)} seconds.`
+                    : totalTime < anHour
+                    ? `${Math.round(totalTime / aMin)} minutes.`
+                    : `${Math.round(totalTime / anHour)} hours.`
             } (every 2 seconds for each items).`
         );
 

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -54,6 +54,7 @@ const ADMIN_COMMANDS: string[] = [
     '!add - Add a pricelist entry ➕',
     '!update - Update a pricelist entry',
     '!relist - Perform relist if some of your listings are missing (you can run only once, then need to wait 30 minutes if you want to run it again)',
+    'resetqueue - Reset queue position to 0',
     '!remove <sku=> OR <item=> - Remove a pricelist entry ➖',
     '!get <sku=> OR <item=> - Get raw information about a pricelist entry',
     '!pricecheck <sku=> OR <item=> - Requests an item to be priced by PricesTF',
@@ -159,6 +160,8 @@ export = class Commands {
             this.checkoutCommand(steamID);
         } else if (command === 'queue') {
             this.queueCommand(steamID);
+        } else if (command === 'resetqueue') {
+            this.resetQueueCommand(steamID);
         } else if (command === 'cancel') {
             this.cancelCommand(steamID);
         } else if (command === 'deposit' && isAdmin) {
@@ -748,6 +751,11 @@ export = class Commands {
         } else {
             this.bot.sendMessage(steamID, `There is ${position} infront of you.`);
         }
+    }
+
+    private resetQueueCommand(steamID: SteamID): void {
+        this.cartQueue.resetQueue();
+        this.bot.sendMessage(steamID, '✅ Sucessfully reset queue!');
     }
 
     private cancelCommand(steamID: SteamID): void {

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -842,51 +842,6 @@ export = class Commands {
                         (currentPosition !== 1 ? 'are' : 'is') +
                         ` ${currentPosition} infront of you.`
                 );
-                clearTimeout(this.queuePositionCheck);
-                log.debug(`Checking queue position in 3 minutes...`);
-                this.queuePositionCheck = setTimeout(() => {
-                    // Check position after 3 minutes
-                    log.debug(`Current queue position: ${position}`);
-                    if (this.cartQueue.getPosition(cart.partner) >= 1) {
-                        if (
-                            process.env.DISABLE_DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT === 'false' &&
-                            process.env.DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT_URL
-                        ) {
-                            const time = (this.bot.handler as MyHandler).timeWithEmoji();
-                            this.discord.sendQueueAlert(position + 1, time.time);
-                            this.bot.botManager
-                                .restartProcess()
-                                .then(restarting => {
-                                    if (!restarting) {
-                                        this.discord.sendQueueAlertFailedPM2(time.time);
-                                    }
-                                })
-                                .catch(err => {
-                                    log.warn('Error occurred while trying to restart: ', err);
-                                    this.discord.sendQueueAlertFailedError(err.message, time.time);
-                                });
-                        } else {
-                            this.bot.messageAdmins(`⚠️ [Queue alert] Current position: ${position + 1}`, []);
-                            this.bot.botManager
-                                .restartProcess()
-                                .then(restarting => {
-                                    if (!restarting) {
-                                        this.bot.messageAdmins(
-                                            '❌ Automatic restart on queue problem failed because are not running the bot with PM2! See the documentation: https://github.com/idinium96/tf2autobot/wiki/e.-Running-with-PM2',
-                                            []
-                                        );
-                                    }
-                                })
-                                .catch(err => {
-                                    log.warn('Error occurred while trying to restart: ', err);
-                                    this.bot.messageAdmins(
-                                        `❌ An error occurred while trying to restart: ${err.message}`,
-                                        []
-                                    );
-                                });
-                        }
-                    }
-                }, 3 * 60 * 1000);
             }
             return;
         }
@@ -900,50 +855,6 @@ export = class Commands {
                     (position !== 1 ? 'are' : 'is') +
                     ` ${position} infront of you.`
             );
-            clearTimeout(this.queuePositionCheck);
-            log.debug(`Checking queue position in 3 minutes...`);
-            this.queuePositionCheck = setTimeout(() => {
-                // Check position after 3 minutes
-                if (this.cartQueue.enqueue(cart) >= 2) {
-                    if (
-                        process.env.DISABLE_DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT === 'false' &&
-                        process.env.DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT_URL
-                    ) {
-                        const time = (this.bot.handler as MyHandler).timeWithEmoji();
-                        this.discord.sendQueueAlert(position + 1, time.time);
-                        this.bot.botManager
-                            .restartProcess()
-                            .then(restarting => {
-                                if (!restarting) {
-                                    this.discord.sendQueueAlertFailedPM2(time.time);
-                                }
-                            })
-                            .catch(err => {
-                                log.warn('Error occurred while trying to restart: ', err);
-                                this.discord.sendQueueAlertFailedError(err.message, time.time);
-                            });
-                    } else {
-                        this.bot.messageAdmins(`⚠️ [Queue alert] Current position: ${position + 1}`, []);
-                        this.bot.botManager
-                            .restartProcess()
-                            .then(restarting => {
-                                if (!restarting) {
-                                    this.bot.messageAdmins(
-                                        '❌ Automatic restart on queue problem failed because are not running the bot with PM2! See the documentation: https://github.com/idinium96/tf2autobot/wiki/e.-Running-with-PM2',
-                                        []
-                                    );
-                                }
-                            })
-                            .catch(err => {
-                                log.warn('Error occurred while trying to restart: ', err);
-                                this.bot.messageAdmins(
-                                    `❌ An error occurred while trying to restart: ${err.message}`,
-                                    []
-                                );
-                            });
-                    }
-                }
-            }, 3 * 60 * 1000);
         }
     }
 

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -66,7 +66,7 @@ const ADMIN_COMMANDS: string[] = [
     '!restart - Restart the bot 🔄',
     '!version - Get version that the bot is running',
     '!autokeys - Get info on your current autoBuy/Sell Keys settings 🔑',
-    '!resfreshautokeys - Refresh your autokeys settings.',
+    '!refreshautokeys - Refresh your autokeys settings.',
     '!avatar <image_URL> - Change avatar',
     '!name <new_name> - Change name',
     '!block <steamid> - Block a specific user',
@@ -484,7 +484,7 @@ export = class Commands {
 
         this.bot.sendMessage(
             steamID,
-            `🎒 My crrent items in my inventory: ${currentItems + (backpackSlots !== 0 ? '/' + backpackSlots : '')}`
+            `🎒 My current items in my inventory: ${currentItems + (backpackSlots !== 0 ? '/' + backpackSlots : '')}`
         );
     }
 

--- a/src/classes/DiscordWebhook.ts
+++ b/src/classes/DiscordWebhook.ts
@@ -265,7 +265,7 @@ export = class DiscordWebhook {
                                 : reasons.includes('⬜STEAM_DOWN')
                                 ? '\n\nSteam down, please manually check if this person have escrow.'
                                 : '') +
-                            `\n\n__Offer Summary__:\n` +
+                            `\n\n__**Offer Summary**__\n` +
                             tradeSummary.replace('Asked:', '**Asked:**').replace('Offered:', '**Offered:**') +
                             (value.diff > 0
                                 ? `\n📈 ***Profit from overpay:*** ${value.diffRef} ref` +
@@ -307,7 +307,7 @@ export = class DiscordWebhook {
                                 : '\n'),
                         fields: [
                             {
-                                name: 'Status',
+                                name: '**Status**',
                                 value:
                                     (isShowKeyRate
                                         ? `\n🔑 Key rate: ${keyPrice.buy.metal.toString()}/${keyPrice.sell.metal.toString()} ref`
@@ -466,7 +466,7 @@ export = class DiscordWebhook {
                         },
                         title: '',
                         description:
-                            `__Summary__:\n` +
+                            `__**Summary**__\n` +
                             tradeSummary.replace('Asked:', '**Asked:**').replace('Offered:', '**Offered:**') +
                             (value.diff > 0
                                 ? `\n📈 ***Profit from overpay:*** ${value.diffRef} ref` +
@@ -480,7 +480,7 @@ export = class DiscordWebhook {
                                 : '\n'),
                         fields: [
                             {
-                                name: 'Status',
+                                name: '__Status__',
                                 value:
                                     (isShowQuickLinks
                                         ? `\n\n🔍 ${partnerNameNoFormat}'s info:\n[Steam Profile](${links.steamProfile}) | [backpack.tf](${links.backpackTF}) | [steamREP](${links.steamREP})\n`
@@ -511,7 +511,7 @@ export = class DiscordWebhook {
                                         : '')
                             },
                             {
-                                name: 'Notes:',
+                                name: '__Notes__',
                                 value: AdditionalNotes ? '\n' + AdditionalNotes : '-'
                             }
                         ],

--- a/src/classes/DiscordWebhook.ts
+++ b/src/classes/DiscordWebhook.ts
@@ -304,11 +304,17 @@ export = class DiscordWebhook {
                             }` +
                             (isShowQuickLinks
                                 ? `\n\n🔍 ${partnerNameNoFormat}'s info:\n[Steam Profile](${links.steamProfile}) | [backpack.tf](${links.backpackTF}) | [steamREP](${links.steamREP})\n`
-                                : '\n') +
-                            (isShowKeyRate
-                                ? `\n🔑 Key rate: ${keyPrice.buy.metal.toString()}/${keyPrice.sell.metal.toString()} ref`
-                                : '') +
-                            (isShowPureStock ? `\n💰 Pure stock: ${pureStock.join(', ').toString()}` : ''),
+                                : '\n'),
+                        fields: [
+                            {
+                                name: 'Status',
+                                value:
+                                    (isShowKeyRate
+                                        ? `\n🔑 Key rate: ${keyPrice.buy.metal.toString()}/${keyPrice.sell.metal.toString()} ref`
+                                        : '') +
+                                    (isShowPureStock ? `\n💰 Pure stock: ${pureStock.join(', ').toString()}` : '')
+                            }
+                        ],
                         color: botEmbedColor
                     }
                 ]
@@ -460,7 +466,7 @@ export = class DiscordWebhook {
                         },
                         title: '',
                         description:
-                            `A trade with ${partnerNameNoFormat} has been marked as accepted.\n__Summary__:\n` +
+                            `__Summary__:\n` +
                             tradeSummary.replace('Asked:', '**Asked:**').replace('Offered:', '**Offered:**') +
                             (value.diff > 0
                                 ? `\n📈 ***Profit from overpay:*** ${value.diffRef} ref` +
@@ -471,29 +477,44 @@ export = class DiscordWebhook {
                                 : '') +
                             (isShowQuickLinks
                                 ? `\n\n🔍 ${partnerNameNoFormat}'s info:\n[Steam Profile](${links.steamProfile}) | [backpack.tf](${links.backpackTF}) | [steamREP](${links.steamREP})\n`
-                                : '\n') +
-                            (isMentionInvalidItems ? '\n\n🟨INVALID_ITEMS:\n' + invalidItemsCombine.join(',\n') : '') +
-                            (isShowKeyRate
-                                ? `\n🔑 Key rate: ${keyPrice.buy.metal.toString()}/${keyPrice.sell.metal.toString()} ref` +
-                                  `${
-                                      isAutoKeysEnabled
-                                          ? ' | Autokeys: ' +
-                                            (autoKeysStatus
-                                                ? '✅' +
-                                                  (isBankingKeys
-                                                      ? ' (banking)'
-                                                      : isBuyingKeys
-                                                      ? ' (buying)'
-                                                      : ' (selling)')
-                                                : '🛑')
-                                          : ''
-                                  }`
-                                : '') +
-                            (isShowPureStock ? `\n💰 Pure stock: ${pureStock.join(', ').toString()}` : '') +
-                            (isShowInventory
-                                ? `\n🎒 Total items: ${currentItems + (backpackSlots !== 0 ? '/' + backpackSlots : '')}`
-                                : '') +
-                            (AdditionalNotes ? '\n' + AdditionalNotes : ''),
+                                : '\n'),
+                        fields: [
+                            {
+                                name: 'Status',
+                                value:
+                                    (isShowQuickLinks
+                                        ? `\n\n🔍 ${partnerNameNoFormat}'s info:\n[Steam Profile](${links.steamProfile}) | [backpack.tf](${links.backpackTF}) | [steamREP](${links.steamREP})\n`
+                                        : '\n') +
+                                    (isMentionInvalidItems
+                                        ? '\n\n🟨INVALID_ITEMS:\n' + invalidItemsCombine.join(',\n')
+                                        : '') +
+                                    (isShowKeyRate
+                                        ? `\n🔑 Key rate: ${keyPrice.buy.metal.toString()}/${keyPrice.sell.metal.toString()} ref` +
+                                          `${
+                                              isAutoKeysEnabled
+                                                  ? ' | Autokeys: ' +
+                                                    (autoKeysStatus
+                                                        ? '✅' +
+                                                          (isBankingKeys
+                                                              ? ' (banking)'
+                                                              : isBuyingKeys
+                                                              ? ' (buying)'
+                                                              : ' (selling)')
+                                                        : '🛑')
+                                                  : ''
+                                          }`
+                                        : '') +
+                                    (isShowPureStock ? `\n💰 Pure stock: ${pureStock.join(', ').toString()}` : '') +
+                                    (isShowInventory
+                                        ? `\n🎒 Total items: ${currentItems +
+                                              (backpackSlots !== 0 ? '/' + backpackSlots : '')}`
+                                        : '')
+                            },
+                            {
+                                name: 'Notes:',
+                                value: AdditionalNotes ? '\n' + AdditionalNotes : '-'
+                            }
+                        ],
                         color: botEmbedColor
                     }
                 ]

--- a/src/classes/DiscordWebhook.ts
+++ b/src/classes/DiscordWebhook.ts
@@ -6,6 +6,7 @@ import log from '../lib/logger';
 import Currencies from 'tf2-currencies';
 import { parseJSON } from '../lib/helpers';
 import MyHandler from './MyHandler';
+import SKU from 'tf2-sku';
 
 export = class DiscordWebhook {
     private readonly bot: Bot;
@@ -387,6 +388,30 @@ export = class DiscordWebhook {
             );
         }
 
+        const invalidItems = theirItemsSecondFiltered.concat(ourItemsSecondFiltered);
+        const invalidItemsName: string[] = [];
+        invalidItems.forEach(sku => {
+            invalidItemsName.push(
+                this.bot.schema
+                    .getName(SKU.fromString(sku), false)
+                    .replace(/Non-Craftable/g, 'NC')
+                    .replace(/Professional Killstreak/g, 'Pro KS')
+                    .replace(/Specialized Killstreak/g, 'Spec KS')
+                    .replace(/Killstreak/g, 'KS')
+            );
+        });
+
+        const invalidItemsFromMyHandler: string[] = [];
+        invalidItemsCombine.forEach(name => {
+            invalidItemsFromMyHandler.push(
+                name
+                    .replace(/Non-Craftable/g, 'NC')
+                    .replace(/Professional Killstreak/g, 'Pro KS')
+                    .replace(/Specialized Killstreak/g, 'Spec KS')
+                    .replace(/Killstreak/g, 'KS')
+            );
+        });
+
         const isMentionInvalidItemsOurSide = ourItemsSecondFiltered.some((sku: string) => {
             if (ourItemsSecondFiltered.length > 0) {
                 return this.bot.pricelist.getPrice(sku, false) === null;
@@ -486,7 +511,10 @@ export = class DiscordWebhook {
                                         ? `\n\n🔍 ${partnerNameNoFormat}'s info:\n[Steam Profile](${links.steamProfile}) | [backpack.tf](${links.backpackTF}) | [steamREP](${links.steamREP})\n`
                                         : '\n') +
                                     (isMentionInvalidItems
-                                        ? '\n\n🟨INVALID_ITEMS:\n' + invalidItemsCombine.join(',\n')
+                                        ? '\n\n🟨INVALID_ITEMS:\n' +
+                                          (invalidItemsCombine.length === 0
+                                              ? invalidItemsName.join(',\n')
+                                              : invalidItemsFromMyHandler.join(',\n'))
                                         : '') +
                                     (isShowKeyRate
                                         ? `\n🔑 Key rate: ${keyPrice.buy.metal.toString()}/${keyPrice.sell.metal.toString()} ref` +

--- a/src/classes/Listings.ts
+++ b/src/classes/Listings.ts
@@ -202,8 +202,8 @@ export = class Listings {
 
                     listing.update({
                         time: match.time || moment().unix(),
-                        details: newDetails,
-                        currencies: currencies
+                        currencies: currencies,
+                        details: newDetails
                     });
                 }
             }

--- a/src/classes/Listings.ts
+++ b/src/classes/Listings.ts
@@ -102,9 +102,6 @@ export = class Listings {
         this.getAccountInfo().asCallback((err, info) => {
             if (err) {
                 log.warn('Failed to get account info from backpack.tf: ', err);
-                clearTimeout(this.autoRelistTimeout);
-                clearTimeout(this.autoRelistRetryTimeout);
-                this.autoRelistRetry = true;
                 return;
             }
 
@@ -117,9 +114,12 @@ export = class Listings {
                 );
                 this.enableAutoRelist();
             } else if (this.autoRelistEnabled && this.autoRelistRetry) {
-                this.autoRelistRetry = false;
                 clearTimeout(this.autoRelistRetryTimeout);
+                clearTimeout(this.autoRelistTimeout);
+
                 log.warn('backpack.tf down, will wait for 5 minutes before reinitializing relist...');
+                this.autoRelistRetry = false;
+
                 this.autoRelistRetryTimeout = setTimeout(() => {
                     this.enableAutoRelist();
                 }, 5 * 60 * 1000);
@@ -462,8 +462,6 @@ export = class Listings {
 
                 this.bot.listingManager.getListings(err => {
                     if (err) {
-                        clearTimeout(this.autoRelistTimeout);
-                        clearTimeout(this.autoRelistRetryTimeout);
                         this.autoRelistRetry = true;
                         return reject(err);
                     }

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -60,13 +60,13 @@ export = class MyHandler extends Handler {
         userMaxReftoScrap: number;
     };
 
-    private autokeysStatus: {
-        isBuyingKeys: boolean;
-        isBankingKeys: boolean;
-        checkAlertOnLowPure: boolean;
-        alreadyUpdatedToBank: boolean;
-        alreadyUpdatedToBuy: boolean;
-        alreadyUpdatedToSell: boolean;
+    private autokeysStatus = {
+        isBuyingKeys: false,
+        isBankingKeys: false,
+        checkAlertOnLowPure: false,
+        alreadyUpdatedToBank: false,
+        alreadyUpdatedToBuy: false,
+        alreadyUpdatedToSell: false
     };
 
     private invalidValueException: number;
@@ -81,6 +81,12 @@ export = class MyHandler extends Handler {
         overstockedItemsSKU: string[];
         dupedItemsSKU: string[];
         dupedFailedItemsSKU: string[];
+    } = {
+        invalidItemsSKU: [],
+        invalidItemsValue: [],
+        overstockedItemsSKU: [],
+        dupedItemsSKU: [],
+        dupedFailedItemsSKU: []
     };
 
     private isTradingKeys = false;

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -948,6 +948,9 @@ export = class MyHandler extends Handler {
             }
         } catch (err) {
             log.warn('Failed to check escrow: ', err);
+            wrongAboutOffer.push({
+                reason: '⬜STEAM_DOWN'
+            });
             const reasons = wrongAboutOffer.map(wrong => wrong.reason);
             const uniqueReasons = reasons.filter(reason => reasons.includes(reason));
 
@@ -972,6 +975,9 @@ export = class MyHandler extends Handler {
             }
         } catch (err) {
             log.warn('Failed to check banned: ', err);
+            wrongAboutOffer.push({
+                reason: '⬜BACKPACKTF_DOWN'
+            });
             const reasons = wrongAboutOffer.map(wrong => wrong.reason);
             const uniqueReasons = reasons.filter(reason => reasons.includes(reason));
 

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -2078,7 +2078,7 @@ Autokeys status:-
                 autoprice: true,
                 max: userMaxKeys,
                 min: userMinKeys,
-                intent: 1
+                intent: 0
             } as any;
         } else {
             entry = {

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -91,6 +91,10 @@ export = class MyHandler extends Handler {
 
     private isTradingKeys = false;
 
+    private autoRelistNotSellingKeys = 0;
+
+    private autoRelistNotBuyingKeys = 0;
+
     private customGameName: string;
 
     private isUsingAutoPrice = true;
@@ -824,14 +828,18 @@ export = class MyHandler extends Handler {
             const priceEntry = this.bot.pricelist.getPrice('5021;6', true);
             if (priceEntry === null) {
                 // We are not trading keys
+                this.autoRelistNotSellingKeys++;
+                this.autoRelistNotBuyingKeys++;
                 offer.log('info', 'we are not trading keys, declining...');
                 return { action: 'decline', reason: 'NOT_TRADING_KEYS' };
             } else if (exchange.our.contains.keys && priceEntry.intent !== 1 && priceEntry.intent !== 2) {
                 // We are not selling keys
+                this.autoRelistNotSellingKeys++;
                 offer.log('info', 'we are not selling keys, declining...');
                 return { action: 'decline', reason: 'NOT_TRADING_KEYS' };
             } else if (exchange.their.contains.keys && priceEntry.intent !== 0 && priceEntry.intent !== 2) {
                 // We are not buying keys
+                this.autoRelistNotBuyingKeys++;
                 offer.log('info', 'we are not buying keys, declining...');
                 return { action: 'decline', reason: 'NOT_TRADING_KEYS' };
             } else {
@@ -854,6 +862,17 @@ export = class MyHandler extends Handler {
                         amountCanTrade: amountCanTrade
                     });
                 }
+            }
+            if (this.autokeysEnabled !== false) {
+                if (this.autoRelistNotSellingKeys > 2 || this.autoRelistNotBuyingKeys > 2) {
+                    log.debug('Our key listings do not synced with Backpack.tf detected, auto-relist initialized.');
+                    this.bot.listings.checkAllWithDelay();
+                    this.autoRelistNotSellingKeys = 0;
+                    this.autoRelistNotBuyingKeys = 0;
+                }
+            } else {
+                this.autoRelistNotSellingKeys = 0;
+                this.autoRelistNotBuyingKeys = 0;
             }
         }
 

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -8,6 +8,7 @@ import { UnknownDictionary } from '../types/common';
 import { Currency } from '../types/TeamFortress2';
 import SKU from 'tf2-sku';
 import request from '@nicklason/request-retry';
+import sleepasync from 'sleep-async';
 
 import SteamUser from 'steam-user';
 import TradeOfferManager, { TradeOffer, PollData } from 'steam-tradeoffer-manager';
@@ -751,7 +752,7 @@ export = class MyHandler extends Handler {
 
                         this.invalidItemsSKU.push(sku);
 
-                        this.sleep(1000);
+                        await sleepasync().Promise.sleep(1 * 1000);
                         const price = await this.bot.pricelist.getPricesTF(sku);
 
                         if (price === null) {

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -717,7 +717,9 @@ export = class MyHandler extends Handler {
                             // User is taking too many / offering too many
                             hasOverstock = true;
 
-                            this.reviewItems.overstockedItemsSKU.push(sku);
+                            if (!['5021;6', '5000;6', '5001;6', '5002;6'].includes(sku)) {
+                                this.reviewItems.overstockedItemsSKU.push(sku);
+                            }
 
                             wrongAboutOffer.push({
                                 reason: '🟦OVERSTOCKED',
@@ -748,7 +750,9 @@ export = class MyHandler extends Handler {
                         // Offer contains an item that we are not trading
                         hasInvalidItems = true;
 
-                        this.reviewItems.invalidItemsSKU.push(sku);
+                        if (!['5021;6', '5000;6', '5001;6', '5002;6'].includes(sku)) {
+                            this.reviewItems.invalidItemsSKU.push(sku);
+                        }
 
                         await sleepasync().Promise.sleep(1 * 1000);
                         const price = await this.bot.pricelist.getPricesTF(sku);

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -51,7 +51,7 @@ export = class MyHandler extends Handler {
 
     private keyBankingEnabled = false;
 
-    private checkAutokeysStatus = false;
+    private autokeysIsActive = false;
 
     private autokeysPure: {
         userMinKeys: number;
@@ -268,7 +268,7 @@ export = class MyHandler extends Handler {
         const status = this.autokeysStatus;
         const settings = {
             enabled: this.autokeysEnabled,
-            status: this.checkAutokeysStatus,
+            status: this.autokeysIsActive,
             minKeys: userPure.userMinKeys,
             maxKeys: userPure.userMaxKeys,
             minRef: userPure.userMinReftoScrap,
@@ -350,7 +350,7 @@ export = class MyHandler extends Handler {
                 return resolve();
             }
 
-            if (process.env.ENABLE_AUTO_SELL_AND_BUY_KEYS === 'true' && this.checkAutokeysStatus === true) {
+            if (process.env.ENABLE_AUTO_SELL_AND_BUY_KEYS === 'true' && this.autokeysIsActive === true) {
                 log.debug('Disabling Autokeys and removing key from pricelist...');
                 this.removeAutoKeys();
             }
@@ -1275,7 +1275,7 @@ export = class MyHandler extends Handler {
                 this.autokeys();
 
                 const isAutoKeysEnabled = this.autokeysEnabled;
-                const autoKeysStatus = this.checkAutokeysStatus;
+                const autoKeysStatus = this.autokeysIsActive;
                 const isBuyingKeys = this.autokeysStatus.isBuyingKeys;
                 const isBankingKeys = this.autokeysStatus.isBankingKeys;
 
@@ -1651,7 +1651,7 @@ export = class MyHandler extends Handler {
         const currKeyPrice = this.bot.pricelist.getKeyPrices();
 
         if (currKeyPrice !== this.OldKeyPrices && !this.isUsingAutoPrice) {
-            // When scrap adjustment activated, if key rate changes, then it will force update key prices.
+            // When scrap adjustment activated, if key rate changes, then it will force update key prices after a trade.
             this.autokeysStatus = {
                 isBuyingKeys: false,
                 isBankingKeys: false,
@@ -1790,7 +1790,7 @@ Autokeys status:-
  }`
         );
 
-        const isAlreadyRunningAutokeys = this.checkAutokeysStatus !== false;
+        const isAlreadyRunningAutokeys = this.autokeysIsActive !== false;
         const isKeysAlreadyExist = this.bot.pricelist.searchByName('Mann Co. Supply Crate Key', false);
         const time = this.timeWithEmoji();
 
@@ -1806,7 +1806,7 @@ Autokeys status:-
                     alreadyUpdatedToBuy: false,
                     alreadyUpdatedToSell: false
                 };
-                this.checkAutokeysStatus = true;
+                this.autokeysIsActive = true;
                 this.updateAutokeysBanking(userMinKeys, userMaxKeys);
             } else if (isBankingBuyKeysWithEnoughRefs && isEnableKeyBanking && isAlreadyUpdatedToBuy !== true) {
                 // enable keys banking - if refs > minRefs but Keys < minKeys, will buy keys.
@@ -1818,7 +1818,7 @@ Autokeys status:-
                     alreadyUpdatedToBuy: true,
                     alreadyUpdatedToSell: false
                 };
-                this.checkAutokeysStatus = true;
+                this.autokeysIsActive = true;
                 this.updateAutokeysBuy(userMinKeys, userMaxKeys);
             } else if (isBuyingKeys && isAlreadyUpdatedToBuy !== true) {
                 // enable Autokeys - Buying - if buying keys conditions matched
@@ -1830,7 +1830,7 @@ Autokeys status:-
                     alreadyUpdatedToBuy: true,
                     alreadyUpdatedToSell: false
                 };
-                this.checkAutokeysStatus = true;
+                this.autokeysIsActive = true;
                 this.updateAutokeysBuy(userMinKeys, userMaxKeys);
             } else if (isSellingKeys && isAlreadyUpdatedToSell !== true) {
                 // enable Autokeys - Selling - if selling keys conditions matched
@@ -1842,7 +1842,7 @@ Autokeys status:-
                     alreadyUpdatedToBuy: false,
                     alreadyUpdatedToSell: true
                 };
-                this.checkAutokeysStatus = true;
+                this.autokeysIsActive = true;
                 this.updateAutokeysSell(userMinKeys, userMaxKeys);
             } else if (isRemoveBankingKeys && isEnableKeyBanking) {
                 // disable keys banking - if to conditions to disable banking matched and banking is enabled
@@ -1854,7 +1854,7 @@ Autokeys status:-
                     alreadyUpdatedToBuy: false,
                     alreadyUpdatedToSell: false
                 };
-                this.checkAutokeysStatus = false;
+                this.autokeysIsActive = false;
                 this.removeAutoKeys();
             } else if (isRemoveAutoKeys && !isEnableKeyBanking) {
                 // disable Autokeys when conditions to disable Autokeys matched
@@ -1866,7 +1866,7 @@ Autokeys status:-
                     alreadyUpdatedToBuy: false,
                     alreadyUpdatedToSell: false
                 };
-                this.checkAutokeysStatus = false;
+                this.autokeysIsActive = false;
                 this.removeAutoKeys();
             } else if (isAlertAdmins && isAlreadyAlert !== true) {
                 // alert admins when low pure
@@ -1878,7 +1878,7 @@ Autokeys status:-
                     alreadyUpdatedToBuy: false,
                     alreadyUpdatedToSell: false
                 };
-                this.checkAutokeysStatus = false;
+                this.autokeysIsActive = false;
                 const msg = 'I am now low on both keys and refs.';
                 if (process.env.DISABLE_SOMETHING_WRONG_ALERT !== 'true') {
                     if (
@@ -1905,7 +1905,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: false,
                         alreadyUpdatedToSell: false
                     };
-                    this.checkAutokeysStatus = true;
+                    this.autokeysIsActive = true;
                     this.createAutokeysBanking(userMinKeys, userMaxKeys);
                 } else if (isBankingBuyKeysWithEnoughRefs && isEnableKeyBanking) {
                     // enable keys banking - if refs > minRefs but Keys < minKeys, will buy keys.
@@ -1917,7 +1917,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: true,
                         alreadyUpdatedToSell: false
                     };
-                    this.checkAutokeysStatus = true;
+                    this.autokeysIsActive = true;
                     this.createAutokeysBuy(userMinKeys, userMaxKeys);
                 } else if (isBuyingKeys) {
                     // create new Key entry and enable Autokeys - Buying - if buying keys conditions matched
@@ -1929,7 +1929,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: true,
                         alreadyUpdatedToSell: false
                     };
-                    this.checkAutokeysStatus = true;
+                    this.autokeysIsActive = true;
                     this.createAutokeysBuy(userMinKeys, userMaxKeys);
                 } else if (isSellingKeys) {
                     // create new Key entry and enable Autokeys - Selling - if selling keys conditions matched
@@ -1941,7 +1941,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: false,
                         alreadyUpdatedToSell: true
                     };
-                    this.checkAutokeysStatus = true;
+                    this.autokeysIsActive = true;
                     this.createAutokeysSell(userMinKeys, userMaxKeys);
                 } else if (isAlertAdmins && isAlreadyAlert !== true) {
                     // alert admins when low pure
@@ -1953,7 +1953,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: false,
                         alreadyUpdatedToSell: false
                     };
-                    this.checkAutokeysStatus = false;
+                    this.autokeysIsActive = false;
                     const msg = 'I am now low on both keys and refs.';
                     if (process.env.DISABLE_SOMETHING_WRONG_ALERT !== 'true') {
                         if (
@@ -1978,7 +1978,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: false,
                         alreadyUpdatedToSell: false
                     };
-                    this.checkAutokeysStatus = true;
+                    this.autokeysIsActive = true;
                     this.updateAutokeysBanking(userMinKeys, userMaxKeys);
                 } else if (isBankingBuyKeysWithEnoughRefs && isEnableKeyBanking && isAlreadyUpdatedToBuy !== true) {
                     // enable keys banking - if refs > minRefs but Keys < minKeys, will buy keys.
@@ -1990,7 +1990,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: true,
                         alreadyUpdatedToSell: false
                     };
-                    this.checkAutokeysStatus = true;
+                    this.autokeysIsActive = true;
                     this.updateAutokeysBuy(userMinKeys, userMaxKeys);
                 } else if (isBuyingKeys && isAlreadyUpdatedToBuy !== true) {
                     // enable Autokeys - Buying - if buying keys conditions matched
@@ -2002,7 +2002,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: true,
                         alreadyUpdatedToSell: false
                     };
-                    this.checkAutokeysStatus = true;
+                    this.autokeysIsActive = true;
                     this.updateAutokeysBuy(userMinKeys, userMaxKeys);
                 } else if (isSellingKeys && isAlreadyUpdatedToSell !== true) {
                     // enable Autokeys - Selling - if selling keys conditions matched
@@ -2014,7 +2014,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: false,
                         alreadyUpdatedToSell: true
                     };
-                    this.checkAutokeysStatus = true;
+                    this.autokeysIsActive = true;
                     this.updateAutokeysSell(userMinKeys, userMaxKeys);
                 } else if (isAlertAdmins && isAlreadyAlert !== true) {
                     // alert admins when low pure
@@ -2026,7 +2026,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: false,
                         alreadyUpdatedToSell: false
                     };
-                    this.checkAutokeysStatus = false;
+                    this.autokeysIsActive = false;
                     const msg = 'I am now low on both keys and refs.';
                     if (process.env.DISABLE_SOMETHING_WRONG_ALERT !== 'true') {
                         if (
@@ -2080,7 +2080,7 @@ Autokeys status:-
             })
             .catch(err => {
                 log.warn(`❌ Failed to add Mann Co. Supply Crate Key to sell automatically: ${err.message}`);
-                this.checkAutokeysStatus = false;
+                this.autokeysIsActive = false;
             })
             .finally(() => {
                 this.bot.listings.checkBySKU('5021;6');
@@ -2124,7 +2124,7 @@ Autokeys status:-
             })
             .catch(err => {
                 log.warn(`❌ Failed to add Mann Co. Supply Crate Key to buy automatically: ${err.message}`);
-                this.checkAutokeysStatus = false;
+                this.autokeysIsActive = false;
             })
             .finally(() => {
                 this.bot.listings.checkBySKU('5021;6');
@@ -2147,7 +2147,7 @@ Autokeys status:-
             })
             .catch(err => {
                 log.warn(`❌ Failed to add Mann Co. Supply Crate Key to bank automatically: ${err.message}`);
-                this.checkAutokeysStatus = false;
+                this.autokeysIsActive = false;
             })
             .finally(() => {
                 this.bot.listings.checkBySKU('5021;6');
@@ -2170,7 +2170,7 @@ Autokeys status:-
             })
             .catch(err => {
                 log.warn(`❌ Failed to disable Autokeys: ${err.message}`);
-                this.checkAutokeysStatus = true;
+                this.autokeysIsActive = true;
             })
             .finally(() => {
                 this.bot.listings.checkBySKU('5021;6');
@@ -2214,7 +2214,7 @@ Autokeys status:-
             })
             .catch(err => {
                 log.warn(`❌ Failed to update Mann Co. Supply Crate Key to sell automatically: ${err.message}`);
-                this.checkAutokeysStatus = false;
+                this.autokeysIsActive = false;
             })
             .finally(() => {
                 this.bot.listings.checkBySKU('5021;6');
@@ -2258,7 +2258,7 @@ Autokeys status:-
             })
             .catch(err => {
                 log.warn(`❌ Failed to update Mann Co. Supply Crate Key to buy automatically: ${err.message}`);
-                this.checkAutokeysStatus = false;
+                this.autokeysIsActive = false;
             })
             .finally(() => {
                 this.bot.listings.checkBySKU('5021;6');
@@ -2281,7 +2281,7 @@ Autokeys status:-
             })
             .catch(err => {
                 log.warn(`❌ Failed to update Mann Co. Supply Crate Key to bank automatically: ${err.message}`);
-                this.checkAutokeysStatus = false;
+                this.autokeysIsActive = false;
             })
             .finally(() => {
                 this.bot.listings.checkBySKU('5021;6');
@@ -2296,7 +2296,7 @@ Autokeys status:-
             })
             .catch(err => {
                 log.warn(`❌ Failed to remove Mann Co. Supply Crate Key automatically: ${err.message}`);
-                this.checkAutokeysStatus = true;
+                this.autokeysIsActive = true;
             })
             .finally(() => {
                 this.bot.listings.checkBySKU('5021;6');
@@ -2313,7 +2313,7 @@ Autokeys status:-
             alreadyUpdatedToBuy: false,
             alreadyUpdatedToSell: false
         };
-        this.checkAutokeysStatus = false;
+        this.autokeysIsActive = false;
         this.sleep(2 * 1000);
         this.autokeys();
     }

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -2007,6 +2007,7 @@ Autokeys status:-
             .addPrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically added Mann Co. Supply Crate Key to sell.`);
+                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to add Mann Co. Supply Crate Key to sell automatically: ${err.message}`);
@@ -2048,6 +2049,7 @@ Autokeys status:-
             .addPrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically added Mann Co. Supply Crate Key to buy.`);
+                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to add Mann Co. Supply Crate Key to buy automatically: ${err.message}`);
@@ -2068,6 +2070,7 @@ Autokeys status:-
             .addPrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically added Mann Co. Supply Crate Key to bank.`);
+                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to add Mann Co. Supply Crate Key to bank automatically: ${err.message}`);
@@ -2088,6 +2091,7 @@ Autokeys status:-
             .updatePrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically disabled Autokeys.`);
+                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to disable Autokeys: ${err.message}`);
@@ -2129,6 +2133,7 @@ Autokeys status:-
             .updatePrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically updated Mann Co. Supply Crate Key to sell.`);
+                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to update Mann Co. Supply Crate Key to sell automatically: ${err.message}`);
@@ -2170,6 +2175,7 @@ Autokeys status:-
             .updatePrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically update Mann Co. Supply Crate Key to buy.`);
+                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to update Mann Co. Supply Crate Key to buy automatically: ${err.message}`);
@@ -2190,6 +2196,7 @@ Autokeys status:-
             .updatePrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically updated Mann Co. Supply Crate Key to bank.`);
+                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to update Mann Co. Supply Crate Key to bank automatically: ${err.message}`);
@@ -2202,6 +2209,7 @@ Autokeys status:-
             .removePrice('5021;6', true)
             .then(() => {
                 log.debug(`✅ Automatically remove Mann Co. Supply Crate Key.`);
+                this.bot.listings.checkBySKU('5021;6');
                 this.checkAutokeysStatus = false;
             })
             .catch(err => {

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -2077,11 +2077,13 @@ Autokeys status:-
             .addPrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically added Mann Co. Supply Crate Key to sell.`);
-                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to add Mann Co. Supply Crate Key to sell automatically: ${err.message}`);
                 this.checkAutokeysStatus = false;
+            })
+            .finally(() => {
+                this.bot.listings.checkBySKU('5021;6');
             });
     }
 
@@ -2119,11 +2121,13 @@ Autokeys status:-
             .addPrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically added Mann Co. Supply Crate Key to buy.`);
-                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to add Mann Co. Supply Crate Key to buy automatically: ${err.message}`);
                 this.checkAutokeysStatus = false;
+            })
+            .finally(() => {
+                this.bot.listings.checkBySKU('5021;6');
             });
     }
 
@@ -2140,11 +2144,13 @@ Autokeys status:-
             .addPrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically added Mann Co. Supply Crate Key to bank.`);
-                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to add Mann Co. Supply Crate Key to bank automatically: ${err.message}`);
                 this.checkAutokeysStatus = false;
+            })
+            .finally(() => {
+                this.bot.listings.checkBySKU('5021;6');
             });
     }
 
@@ -2161,11 +2167,13 @@ Autokeys status:-
             .updatePrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically disabled Autokeys.`);
-                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to disable Autokeys: ${err.message}`);
                 this.checkAutokeysStatus = true;
+            })
+            .finally(() => {
+                this.bot.listings.checkBySKU('5021;6');
             });
     }
 
@@ -2203,11 +2211,13 @@ Autokeys status:-
             .updatePrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically updated Mann Co. Supply Crate Key to sell.`);
-                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to update Mann Co. Supply Crate Key to sell automatically: ${err.message}`);
                 this.checkAutokeysStatus = false;
+            })
+            .finally(() => {
+                this.bot.listings.checkBySKU('5021;6');
             });
     }
 
@@ -2245,11 +2255,13 @@ Autokeys status:-
             .updatePrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically update Mann Co. Supply Crate Key to buy.`);
-                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to update Mann Co. Supply Crate Key to buy automatically: ${err.message}`);
                 this.checkAutokeysStatus = false;
+            })
+            .finally(() => {
+                this.bot.listings.checkBySKU('5021;6');
             });
     }
 
@@ -2266,11 +2278,13 @@ Autokeys status:-
             .updatePrice(entry as EntryData, true)
             .then(() => {
                 log.debug(`✅ Automatically updated Mann Co. Supply Crate Key to bank.`);
-                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to update Mann Co. Supply Crate Key to bank automatically: ${err.message}`);
                 this.checkAutokeysStatus = false;
+            })
+            .finally(() => {
+                this.bot.listings.checkBySKU('5021;6');
             });
     }
 
@@ -2279,11 +2293,13 @@ Autokeys status:-
             .removePrice('5021;6', true)
             .then(() => {
                 log.debug(`✅ Automatically remove Mann Co. Supply Crate Key.`);
-                this.bot.listings.checkBySKU('5021;6');
             })
             .catch(err => {
                 log.warn(`❌ Failed to remove Mann Co. Supply Crate Key automatically: ${err.message}`);
                 this.checkAutokeysStatus = true;
+            })
+            .finally(() => {
+                this.bot.listings.checkBySKU('5021;6');
             });
     }
 

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1789,6 +1789,7 @@ Autokeys status:-
                     alreadyUpdatedToBuy: false,
                     alreadyUpdatedToSell: false
                 };
+                this.checkAutokeysStatus = true;
                 this.updateAutokeysBanking(userMinKeys, userMaxKeys);
             } else if (isBankingBuyKeysWithEnoughRefs && isEnableKeyBanking && isAlreadyUpdatedToBuy !== true) {
                 // enable keys banking - if refs > minRefs but Keys < minKeys, will buy keys.
@@ -1812,6 +1813,7 @@ Autokeys status:-
                     alreadyUpdatedToBuy: true,
                     alreadyUpdatedToSell: false
                 };
+                this.checkAutokeysStatus = true;
                 this.updateAutokeysBuy(userMinKeys, userMaxKeys);
             } else if (isSellingKeys && isAlreadyUpdatedToSell !== true) {
                 // enable Autokeys - Selling - if selling keys conditions matched
@@ -1823,6 +1825,7 @@ Autokeys status:-
                     alreadyUpdatedToBuy: false,
                     alreadyUpdatedToSell: true
                 };
+                this.checkAutokeysStatus = true;
                 this.updateAutokeysSell(userMinKeys, userMaxKeys);
             } else if (isRemoveBankingKeys && isEnableKeyBanking) {
                 // disable keys banking - if to conditions to disable banking matched and banking is enabled
@@ -1834,6 +1837,7 @@ Autokeys status:-
                     alreadyUpdatedToBuy: false,
                     alreadyUpdatedToSell: false
                 };
+                this.checkAutokeysStatus = false;
                 this.removeAutoKeys();
             } else if (isRemoveAutoKeys && !isEnableKeyBanking) {
                 // disable Autokeys when conditions to disable Autokeys matched
@@ -1845,6 +1849,7 @@ Autokeys status:-
                     alreadyUpdatedToBuy: false,
                     alreadyUpdatedToSell: false
                 };
+                this.checkAutokeysStatus = false;
                 this.removeAutoKeys();
             } else if (isAlertAdmins && isAlreadyAlert !== true) {
                 // alert admins when low pure
@@ -1883,6 +1888,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: false,
                         alreadyUpdatedToSell: false
                     };
+                    this.checkAutokeysStatus = true;
                     this.createAutokeysBanking(userMinKeys, userMaxKeys);
                 } else if (isBankingBuyKeysWithEnoughRefs && isEnableKeyBanking) {
                     // enable keys banking - if refs > minRefs but Keys < minKeys, will buy keys.
@@ -1894,6 +1900,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: false,
                         alreadyUpdatedToSell: false
                     };
+                    this.checkAutokeysStatus = true;
                     this.createAutokeysBuy(userMinKeys, userMaxKeys);
                 } else if (isBuyingKeys) {
                     // create new Key entry and enable Autokeys - Buying - if buying keys conditions matched
@@ -1905,6 +1912,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: false,
                         alreadyUpdatedToSell: false
                     };
+                    this.checkAutokeysStatus = true;
                     this.createAutokeysBuy(userMinKeys, userMaxKeys);
                 } else if (isSellingKeys) {
                     // create new Key entry and enable Autokeys - Selling - if selling keys conditions matched
@@ -1916,6 +1924,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: false,
                         alreadyUpdatedToSell: false
                     };
+                    this.checkAutokeysStatus = true;
                     this.createAutokeysSell(userMinKeys, userMaxKeys);
                 } else if (isAlertAdmins && isAlreadyAlert !== true) {
                     // alert admins when low pure
@@ -1952,6 +1961,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: false,
                         alreadyUpdatedToSell: false
                     };
+                    this.checkAutokeysStatus = true;
                     this.updateAutokeysBanking(userMinKeys, userMaxKeys);
                 } else if (isBankingBuyKeysWithEnoughRefs && isEnableKeyBanking && isAlreadyUpdatedToBuy !== true) {
                     // enable keys banking - if refs > minRefs but Keys < minKeys, will buy keys.
@@ -1963,6 +1973,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: true,
                         alreadyUpdatedToSell: false
                     };
+                    this.checkAutokeysStatus = true;
                     this.updateAutokeysBuy(userMinKeys, userMaxKeys);
                 } else if (isBuyingKeys && isAlreadyUpdatedToBuy !== true) {
                     // enable Autokeys - Buying - if buying keys conditions matched
@@ -1974,6 +1985,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: true,
                         alreadyUpdatedToSell: false
                     };
+                    this.checkAutokeysStatus = true;
                     this.updateAutokeysBuy(userMinKeys, userMaxKeys);
                 } else if (isSellingKeys && isAlreadyUpdatedToSell !== true) {
                     // enable Autokeys - Selling - if selling keys conditions matched
@@ -1985,6 +1997,7 @@ Autokeys status:-
                         alreadyUpdatedToBuy: false,
                         alreadyUpdatedToSell: true
                     };
+                    this.checkAutokeysStatus = true;
                     this.updateAutokeysSell(userMinKeys, userMaxKeys);
                 } else if (isAlertAdmins && isAlreadyAlert !== true) {
                     // alert admins when low pure
@@ -2048,7 +2061,6 @@ Autokeys status:-
             .then(() => {
                 log.debug(`✅ Automatically added Mann Co. Supply Crate Key to sell.`);
                 this.bot.listings.checkBySKU('5021;6');
-                this.checkAutokeysStatus = true;
             })
             .catch(err => {
                 log.warn(`❌ Failed to add Mann Co. Supply Crate Key to sell automatically: ${err.message}`);
@@ -2091,7 +2103,6 @@ Autokeys status:-
             .then(() => {
                 log.debug(`✅ Automatically added Mann Co. Supply Crate Key to buy.`);
                 this.bot.listings.checkBySKU('5021;6');
-                this.checkAutokeysStatus = true;
             })
             .catch(err => {
                 log.warn(`❌ Failed to add Mann Co. Supply Crate Key to buy automatically: ${err.message}`);
@@ -2113,7 +2124,6 @@ Autokeys status:-
             .then(() => {
                 log.debug(`✅ Automatically added Mann Co. Supply Crate Key to bank.`);
                 this.bot.listings.checkBySKU('5021;6');
-                this.checkAutokeysStatus = true;
             })
             .catch(err => {
                 log.warn(`❌ Failed to add Mann Co. Supply Crate Key to bank automatically: ${err.message}`);
@@ -2135,7 +2145,6 @@ Autokeys status:-
             .then(() => {
                 log.debug(`✅ Automatically disabled Autokeys.`);
                 this.bot.listings.checkBySKU('5021;6');
-                this.checkAutokeysStatus = false;
             })
             .catch(err => {
                 log.warn(`❌ Failed to disable Autokeys: ${err.message}`);
@@ -2178,7 +2187,6 @@ Autokeys status:-
             .then(() => {
                 log.debug(`✅ Automatically updated Mann Co. Supply Crate Key to sell.`);
                 this.bot.listings.checkBySKU('5021;6');
-                this.checkAutokeysStatus = true;
             })
             .catch(err => {
                 log.warn(`❌ Failed to update Mann Co. Supply Crate Key to sell automatically: ${err.message}`);
@@ -2221,7 +2229,6 @@ Autokeys status:-
             .then(() => {
                 log.debug(`✅ Automatically update Mann Co. Supply Crate Key to buy.`);
                 this.bot.listings.checkBySKU('5021;6');
-                this.checkAutokeysStatus = true;
             })
             .catch(err => {
                 log.warn(`❌ Failed to update Mann Co. Supply Crate Key to buy automatically: ${err.message}`);
@@ -2243,7 +2250,6 @@ Autokeys status:-
             .then(() => {
                 log.debug(`✅ Automatically updated Mann Co. Supply Crate Key to bank.`);
                 this.bot.listings.checkBySKU('5021;6');
-                this.checkAutokeysStatus = true;
             })
             .catch(err => {
                 log.warn(`❌ Failed to update Mann Co. Supply Crate Key to bank automatically: ${err.message}`);
@@ -2257,7 +2263,6 @@ Autokeys status:-
             .then(() => {
                 log.debug(`✅ Automatically remove Mann Co. Supply Crate Key.`);
                 this.bot.listings.checkBySKU('5021;6');
-                this.checkAutokeysStatus = false;
             })
             .catch(err => {
                 log.warn(`❌ Failed to remove Mann Co. Supply Crate Key automatically: ${err.message}`);

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -105,6 +105,8 @@ export = class MyHandler extends Handler {
 
     private isAcceptedWithInvalidItemsOrOverstocked = false;
 
+    private OldKeyPrices: { buy: Currencies; sell: Currencies };
+
     recentlySentMessage: UnknownDictionary<number> = {};
 
     constructor(bot: Bot) {
@@ -1645,6 +1647,21 @@ export = class MyHandler extends Handler {
         const userMaxKeys = userPure.userMaxKeys;
         const userMinReftoScrap = userPure.userMinReftoScrap;
         const userMaxReftoScrap = userPure.userMaxReftoScrap;
+
+        const currKeyPrice = this.bot.pricelist.getKeyPrices();
+
+        if (currKeyPrice !== this.OldKeyPrices && !this.isUsingAutoPrice) {
+            // When scrap adjustment activated, if key rate changes, then it will force update key prices.
+            this.autokeysStatus = {
+                isBuyingKeys: false,
+                isBankingKeys: false,
+                checkAlertOnLowPure: false,
+                alreadyUpdatedToBank: false,
+                alreadyUpdatedToBuy: false,
+                alreadyUpdatedToSell: false
+            };
+            this.OldKeyPrices = { buy: currKeyPrice.buy, sell: currKeyPrice.sell };
+        }
 
         if (isNaN(userMinKeys) || isNaN(userMinReftoScrap) || isNaN(userMaxReftoScrap)) {
             log.warn(

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -88,10 +88,6 @@ export = class MyHandler extends Handler {
 
     private isTradingKeys = false;
 
-    private autoRelistNotSellingKeys = 0;
-
-    private autoRelistNotBuyingKeys = 0;
-
     private hasInvalidValueException = false;
 
     private customGameName: string;
@@ -824,12 +820,10 @@ export = class MyHandler extends Handler {
             } else if (exchange.our.contains.keys && priceEntry.intent !== 1 && priceEntry.intent !== 2) {
                 // We are not selling keys
                 offer.log('info', 'we are not selling keys, declining...');
-                this.autoRelistNotSellingKeys++;
                 return { action: 'decline', reason: 'NOT_TRADING_KEYS' };
             } else if (exchange.their.contains.keys && priceEntry.intent !== 0 && priceEntry.intent !== 2) {
                 // We are not buying keys
                 offer.log('info', 'we are not buying keys, declining...');
-                this.autoRelistNotBuyingKeys++;
                 return { action: 'decline', reason: 'NOT_TRADING_KEYS' };
             } else {
                 // Check overstock / understock on keys
@@ -851,17 +845,6 @@ export = class MyHandler extends Handler {
                         amountCanTrade: amountCanTrade
                     });
                 }
-            }
-            if (this.autokeysEnabled !== false) {
-                if (this.autoRelistNotSellingKeys > 2 || this.autoRelistNotBuyingKeys > 2) {
-                    log.debug('Our key listings do not synced with Backpack.tf detected, auto-relist initialized.');
-                    this.bot.listings.checkAllWithDelay();
-                    this.autoRelistNotSellingKeys = 0;
-                    this.autoRelistNotBuyingKeys = 0;
-                }
-            } else {
-                this.autoRelistNotSellingKeys = 0;
-                this.autoRelistNotBuyingKeys = 0;
             }
         }
 

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1884,7 +1884,7 @@ Autokeys status:-
                         isBuyingKeys: false,
                         isBankingKeys: true,
                         checkAlertOnLowPure: false,
-                        alreadyUpdatedToBank: false,
+                        alreadyUpdatedToBank: true,
                         alreadyUpdatedToBuy: false,
                         alreadyUpdatedToSell: false
                     };
@@ -1897,7 +1897,7 @@ Autokeys status:-
                         isBankingKeys: false,
                         checkAlertOnLowPure: false,
                         alreadyUpdatedToBank: false,
-                        alreadyUpdatedToBuy: false,
+                        alreadyUpdatedToBuy: true,
                         alreadyUpdatedToSell: false
                     };
                     this.checkAutokeysStatus = true;
@@ -1909,7 +1909,7 @@ Autokeys status:-
                         isBankingKeys: false,
                         checkAlertOnLowPure: false,
                         alreadyUpdatedToBank: false,
-                        alreadyUpdatedToBuy: false,
+                        alreadyUpdatedToBuy: true,
                         alreadyUpdatedToSell: false
                     };
                     this.checkAutokeysStatus = true;
@@ -1922,7 +1922,7 @@ Autokeys status:-
                         checkAlertOnLowPure: false,
                         alreadyUpdatedToBank: false,
                         alreadyUpdatedToBuy: false,
-                        alreadyUpdatedToSell: false
+                        alreadyUpdatedToSell: true
                     };
                     this.checkAutokeysStatus = true;
                     this.createAutokeysSell(userMinKeys, userMaxKeys);

--- a/src/lib/extend/offer/summarizeWithLink.ts
+++ b/src/lib/extend/offer/summarizeWithLink.ts
@@ -52,7 +52,12 @@ function summarizeItemsWithLink(dict: UnknownDictionary<number>, schema: SchemaM
         }
 
         const amount = dict[sku];
-        const name = schema.getName(SKU.fromString(sku), false);
+        const name = schema
+            .getName(SKU.fromString(sku), false)
+            .replace(/Non-Craftable/g, 'NC')
+            .replace(/Professional Killstreak/g, 'Pro KS')
+            .replace(/Specialized Killstreak/g, 'Spec KS')
+            .replace(/Killstreak/g, 'KS');
 
         summary.push('[' + name + '](https://www.prices.tf/items/' + sku + ')' + (amount > 1 ? ' x' + amount : ''));
     }

--- a/src/lib/extend/offer/summarizeWithLink.ts
+++ b/src/lib/extend/offer/summarizeWithLink.ts
@@ -66,5 +66,12 @@ function summarizeItemsWithLink(dict: UnknownDictionary<number>, schema: SchemaM
         return 'nothing';
     }
 
-    return summary.join(', ');
+    let left = 0;
+
+    if (summary.length > 15) {
+        left = summary.length - 15;
+        summary.splice(15);
+    }
+
+    return summary.join(', ') + (left !== 0 ? ' and ' + left + ' more items.' : '');
 }


### PR DESCRIPTION
**Added**
- `!resetqueue` command (9f8edb4)
- filter key/metal from invalid_items/overstocked (just in case it appear again) (8a06421)
- fields in Discord Webhook (968f281)

**Changed**
- update/clean MyHandler.ts/Autokeys (afe0a09, 0700051, a627fbd, 85647c5, 50a7f6c, b4862ad, b4862ad)
- replace long item name with Pro KS, Spec KS, KS, NC (7e2abef)
- limit only 15 items to show in Offered/Asked summary (00d97c8)
- check queue directly in CartQueue.ts (279095f)
- use finally on check (bcab485)

**Fixed**
- typo (308b622)
- possible fix autobump (775447b)
- `⬜STEAM_DOWN` or `⬜BACKPACKTF_DOWN` reason not appeared (c2a2bf9)
- wrong Autokeys intent (fe7001d)
- Autokeys: key price not updated with current key rate when scrap adjustment activated (b3aba46)
- not show invalid items after accepting review (only when mention not reset) (9ad9046)