### PR TITLE
change 'offer expired' message

### DIFF
--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1248,7 +1248,7 @@ export = class MyHandler extends Handler {
                         reason = 'Failed to accept mobile confirmation';
                     } else {
                         reason =
-                            "The offer has been active for a while. If the offer was just created,  is likely an issue on Steam's end. Please try again later";
+                            "The offer has been active for a while. If the offer was just created, this is likely an issue on Steam's end. Please try again later";
                     }
 
                     this.bot.sendMessage(

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1247,7 +1247,8 @@ export = class MyHandler extends Handler {
                     } else if (oldState === TradeOfferManager.ETradeOfferState.CreatedNeedsConfirmation) {
                         reason = 'Failed to accept mobile confirmation';
                     } else {
-                        reason = 'The offer has been active for a while';
+                        reason =
+                            "The offer has been active for a while. If the offer was just created,  is likely an issue on Steam's end. Please try again later";
                     }
 
                     this.bot.sendMessage(


### PR DESCRIPTION
Change message/reason of 'The offer has been active for a while' to 'The offer has been active for a while. If the offer was just created, this is likely an issue on Steam's end. Please try again later'.

This message is sent when Steam trading is down, so it's important to also note that this is a very likely scenario rather than the trade being active for too long. This will clear up confusion/frustration when a customer receives this message within seconds of making the trade.