### PR TITLE
v1.6.2 - minor fix/changes

### DIFF
--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -826,6 +826,7 @@ export = class MyHandler extends Handler {
         if (this.fromEnv.checkUses.duelEnabled || this.fromEnv.checkUses.noiseEnabled) {
             let hasNot5Uses = false;
             let hasNot25Uses = false;
+            const noiseMakerSKU: string[] = [];
 
             offer.itemsToReceive.forEach(item => {
                 const isDuelingMiniGame = item.market_hash_name === 'Dueling Mini-Game';
@@ -859,6 +860,8 @@ export = class MyHandler extends Handler {
                             descriptionColor === '00a000'
                         ) {
                             hasNot25Uses = true;
+                            noiseMakerSKU.push(item.getSKU(this.bot.schema));
+
                             log.debug('info', `${item.market_hash_name} (${item.assetid}) is not 25 uses.`);
                             break;
                         }
@@ -872,7 +875,7 @@ export = class MyHandler extends Handler {
                 return { action: 'decline', reason: 'DUELING_NOT_5_USES' };
             }
 
-            const isHasNoiseMaker = this.noiseMakerSKUs().some(sku => {
+            const isHasNoiseMaker = noiseMakerSKU.some(sku => {
                 return checkExist.getPrice(sku, true) !== null;
             });
 

--- a/src/lib/bans.ts
+++ b/src/lib/bans.ts
@@ -56,7 +56,7 @@ function isBptfSteamRepBanned(steamID: SteamID | string): Promise<boolean> {
                 }
 
                 const user = body.users[steamID64];
-                const isSteamRepBanned = user.bans ? user.bans.steamrep_scammer : false;
+                const isSteamRepBanned = user.bans ? user.bans.steamrep_scammer === 1 : false;
 
                 return resolve(isSteamRepBanned);
             }


### PR DESCRIPTION
**Fix**
- the `Array.some()` method when checking whether Noise Maker exists in the pricelist or not. Previously it checks the entire Noise Maker sku instead of the only sku that is/are being checked. (7a4b8c5)

**Changes**
- add missing boolean (stricter type) when checking if trade partner is marked as scammer based on backpack.tf API. The bot will always check if trade partner is a scammer based on Steamrep.com, but if and only if something is wrong with Steamrep, then it will refer to backpack.tf API. (6fb563b)