### PR TITLE
v1.6.5

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -44,7 +44,7 @@ SchemaManager.prototype.getSchema = function(callback): void {
             this.setSchema(schema, true);
             callback(null, this.schema);
         })
-        .catch(function(err) {
+        .catch(err => {
             callback(err);
         });
 };
@@ -59,7 +59,7 @@ import ON_DEATH from 'death';
 // This error is a false positive.
 // The signal and err are being created dynamically.
 // Treat them as any for now.
-ON_DEATH({ uncaughtException: true })(function(signal, err) {
+ON_DEATH({ uncaughtException: true })((signal, err) => {
     const crashed = typeof err !== 'string';
 
     if (crashed) {
@@ -95,7 +95,7 @@ ON_DEATH({ uncaughtException: true })(function(signal, err) {
     botManager.stop(crashed ? err : null, true, signal === 'SIGKILL');
 });
 
-process.on('message', function(message) {
+process.on('message', message => {
     if (message === 'shutdown') {
         log.warn('Process received shutdown message, stopping...');
 
@@ -108,18 +108,18 @@ process.on('message', function(message) {
 import EconItem from 'steam-tradeoffer-manager/lib/classes/EconItem.js';
 import CEconItem from 'steamcommunity/classes/CEconItem.js';
 
-['hasDescription', 'getAction', 'getTag', 'getSKU'].forEach(function(v) {
+['hasDescription', 'getAction', 'getTag', 'getSKU'].forEach(v => {
     EconItem.prototype[v] = require('./lib/extend/item/' + v);
     CEconItem.prototype[v] = require('./lib/extend/item/' + v);
 });
 
 import TradeOffer from 'steam-tradeoffer-manager/lib/classes/TradeOffer';
 
-['log', 'summarize', 'getDiff', 'summarizeWithLink', 'summarizeSKU'].forEach(function(v) {
+['log', 'summarize', 'getDiff', 'summarizeWithLink', 'summarizeSKU'].forEach(v => {
     TradeOffer.prototype[v] = require('./lib/extend/offer/' + v);
 });
 
-botManager.start().asCallback(function(err) {
+botManager.start().asCallback(err => {
     if (err) {
         throw err;
     }

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -126,7 +126,7 @@ export = class Bot {
             (steamID: string) => new SteamID(steamID)
         );
 
-        this.admins.forEach(function(steamID) {
+        this.admins.forEach(steamID => {
             if (!steamID.isValid()) {
                 throw new Error('Invalid admin steamID');
             }
@@ -269,7 +269,7 @@ export = class Bot {
                     url: 'https://raw.githubusercontent.com/idinium96/tf2autobot/master/package.json',
                     json: true
                 },
-                function(err, response, body) {
+                (err, response, body) => {
                     if (err) {
                         return reject(err);
                     }
@@ -330,7 +330,7 @@ export = class Bot {
                             'Checking account limitations - Please disable this in the config by setting `SKIP_ACCOUNT_LIMITATIONS` to true'
                         );
 
-                        this.getAccountLimitations().asCallback(function(err, limitations) {
+                        this.getAccountLimitations().asCallback((err, limitations) => {
                             if (err) {
                                 return callback(err);
                             }
@@ -500,7 +500,7 @@ export = class Bot {
         this.community.setCookies(cookies);
 
         return new Promise((resolve, reject) => {
-            this.manager.setCookies(cookies, function(err) {
+            this.manager.setCookies(cookies, err => {
                 if (err) {
                     return reject(err);
                 }
@@ -569,7 +569,7 @@ export = class Bot {
         return this.community._jar
             .getCookies('https://steamcommunity.com')
             .filter(cookie => ['sessionid', 'steamLogin', 'steamLoginSecure'].includes(cookie.key))
-            .map(function(cookie) {
+            .map(cookie => {
                 return `${cookie.key}=${cookie.value}`;
             });
     }
@@ -598,7 +598,7 @@ export = class Bot {
 
     private getBptfAccessToken(): Promise<string> {
         return new Promise((resolve, reject) => {
-            this.bptf.getAccessToken(function(err, accessToken) {
+            this.bptf.getAccessToken((err, accessToken) => {
                 if (err) {
                     return reject(err);
                 }
@@ -786,7 +786,7 @@ export = class Bot {
     private onConfKeyNeeded(tag: string, callback: (err: Error | null, time: number, confKey: string) => void): void {
         log.debug('Conf key needed');
 
-        this.getTimeOffset().asCallback(function(err, offset) {
+        this.getTimeOffset().asCallback((err, offset) => {
             const time = SteamTotp.time(offset);
             const confKey = SteamTotp.getConfirmationKey(process.env.STEAM_IDENTITY_SECRET, time, tag);
 
@@ -840,7 +840,7 @@ export = class Bot {
 
             log.warn('Login session replaced, relogging...');
 
-            this.login().asCallback(function(err) {
+            this.login().asCallback(err => {
                 if (err) {
                     throw err;
                 }

--- a/src/classes/BotManager.ts
+++ b/src/classes/BotManager.ts
@@ -38,11 +38,11 @@ export = class BotManager {
             this.socket.emit('authentication', process.env.PRICESTF_API_TOKEN || undefined);
         });
 
-        this.socket.on('authenticated', function() {
+        this.socket.on('authenticated', () => {
             log.debug('Authenticated with socket server');
         });
 
-        this.socket.on('unauthorized', function(err) {
+        this.socket.on('unauthorized', err => {
             log.debug('Failed to authenticate with socket server', {
                 error: err
             });
@@ -75,7 +75,7 @@ export = class BotManager {
 
     start(): Promise<void> {
         return new Promise((resolve, reject) => {
-            REQUIRED_OPTS.forEach(function(optName) {
+            REQUIRED_OPTS.forEach(optName => {
                 if (!process.env[optName]) {
                     return reject(new Error(`Missing required environment variable "${optName}"`));
                 }
@@ -179,7 +179,7 @@ export = class BotManager {
 
             log.warn('Stop has been requested, stopping...');
 
-            pm2.stop(process.env.pm_id, function(err) {
+            pm2.stop(process.env.pm_id, err => {
                 if (err) {
                     return reject(err);
                 }
@@ -199,7 +199,7 @@ export = class BotManager {
 
             log.warn('Restart has been initialized, restarting...');
 
-            pm2.restart(process.env.pm_id, function(err) {
+            pm2.restart(process.env.pm_id, err => {
                 if (err) {
                     return reject(err);
                 }
@@ -245,10 +245,10 @@ export = class BotManager {
         }
 
         log.debug('Waiting for files to be saved');
-        waitForWriting().then(function() {
+        waitForWriting().then(() => {
             log.debug('Done waiting for files');
 
-            log.on('finish', function() {
+            log.on('finish', () => {
                 // Logger has finished, exit the process
                 process.exit(err ? 1 : 0);
             });
@@ -262,7 +262,7 @@ export = class BotManager {
 
     connectToPM2(): Promise<void> {
         return new Promise((resolve, reject) => {
-            pm2.connect(function(err) {
+            pm2.connect(err => {
                 if (err) {
                     return reject(err);
                 }
@@ -274,7 +274,7 @@ export = class BotManager {
 
     initializeSchema(): Promise<void> {
         return new Promise((resolve, reject) => {
-            this.schemaManager.init(function(err) {
+            this.schemaManager.init(err => {
                 if (err) {
                     return reject(err);
                 }

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -898,7 +898,7 @@ export = class Commands {
             });
         }
 
-        items.sort(function(a, b) {
+        items.sort((a, b) => {
             if (a.amount === b.amount) {
                 if (a.name < b.name) {
                     return -1;
@@ -1036,7 +1036,7 @@ export = class Commands {
             });
         });
 
-        sales.sort(function(a, b) {
+        sales.sort((a, b) => {
             return b.date - a.date;
         });
 
@@ -1829,7 +1829,7 @@ export = class Commands {
 
         const sendMessage = this.bot;
 
-        this.bot.client.blockUser(targetSteamID64, function(err) {
+        this.bot.client.blockUser(targetSteamID64, err => {
             if (err) {
                 log.warn(`Failed to block user ${targetSteamID64}: `, err);
                 sendMessage.sendMessage(steamID, `❌ Failed to block user ${targetSteamID64}: ${err}`);
@@ -1856,7 +1856,7 @@ export = class Commands {
 
         const sendMessage = this.bot;
 
-        this.bot.client.unblockUser(targetSteamID64, function(err) {
+        this.bot.client.unblockUser(targetSteamID64, err => {
             if (err) {
                 log.warn(`Failed to unblock user ${targetSteamID64}: `, err);
                 sendMessage.sendMessage(steamID, `❌ Failed to unblock user ${targetSteamID64}: ${err}`);
@@ -3112,7 +3112,7 @@ export = class Commands {
             }
         });
 
-        items.sort(function(a, b) {
+        items.sort((a, b) => {
             if (a.amount === b.amount) {
                 if (a.name < b.name) {
                     return -1;
@@ -3150,7 +3150,7 @@ export = class Commands {
             }
         });
 
-        items.sort(function(a, b) {
+        items.sort((a, b) => {
             if (a.amount === b.amount) {
                 if (a.name < b.name) {
                     return -1;

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -2651,6 +2651,7 @@ export = class Commands {
         }
 
         params.sku = SKU.fromObject(fixItem(SKU.fromString(params.sku), this.bot.schema));
+        const name = this.bot.schema.getName(SKU.fromString(params.sku), false);
 
         requestCheck(params.sku, 'bptf').asCallback((err, body) => {
             if (err) {
@@ -2662,7 +2663,16 @@ export = class Commands {
                 return;
             }
 
-            this.bot.sendMessage(steamID, `⌛ Price check requested for ${body.name}, the item will be checked.`);
+            this.bot.sendMessage(
+                steamID,
+                `⌛ Price check requested for ${
+                    body.name.includes('War Paint') ||
+                    body.name.includes('Mann Co. Supply Crate Series #') ||
+                    body.name.includes('Salvaged Mann Co. Supply Crate #')
+                        ? name
+                        : body.name
+                }, the item will be checked.`
+            );
         });
     }
 

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -848,10 +848,10 @@ export = class Commands {
         const diffTime = now - uptime;
 
         const printTime =
-            diffTime >= 77400 * 1000 && diffTime < 127800 * 1000 // 21.5 h - 35.5 hours will show "a day", so show hours in bracket.
-                ? ' (' + Math.round((diffTime / 3600) * 1000) + ' hours)'
-                : diffTime >= 2203200 * 1000 // More than 25.5 days, will become "a month", so show how many days in bracket.
-                ? ' (' + Math.round((diffTime / 86400) * 1000) + ' days)'
+            diffTime >= 21.5 * 60 * 60 * 1000 && diffTime < 35.5 * 60 * 60 * 1000 // 21.5 h - 35.5 hours will show "a day", so show hours in bracket.
+                ? ' (' + Math.round(diffTime / (1 * 60 * 60 * 1000)) + ' hours)'
+                : diffTime >= 25.5 * 24 * 60 * 60 * 1000 // More than 25.5 days, will become "a month", so show how many days in bracket.
+                ? ' (' + Math.round(diffTime / (1 * 24 * 60 * 60 * 1000)) + ' days)'
                 : '';
 
         this.bot.sendMessage(steamID, `Bot has been up for ${moment(uptime).fromNow(true) + printTime}.`);

--- a/src/classes/DiscordWebhook.ts
+++ b/src/classes/DiscordWebhook.ts
@@ -17,10 +17,6 @@ export = class DiscordWebhookClass {
 
     private ownerID: string;
 
-    private botName: string;
-
-    private botAvatarURL: string;
-
     private botEmbedColor: string;
 
     tradeSummaryLinks: string[];
@@ -34,12 +30,6 @@ export = class DiscordWebhookClass {
 
         const ownerID = process.env.DISCORD_OWNER_ID;
         this.ownerID = ownerID;
-
-        const botName = process.env.DISCORD_WEBHOOK_USERNAME;
-        this.botName = botName;
-
-        const botAvatarURL = process.env.DISCORD_WEBHOOK_AVATAR_URL;
-        this.botAvatarURL = botAvatarURL;
 
         const botEmbedColor = process.env.DISCORD_WEBHOOK_EMBED_COLOR_IN_DECIMAL_INDEX;
         this.botEmbedColor = botEmbedColor;
@@ -110,10 +100,14 @@ export = class DiscordWebhookClass {
             color = '8323327'; // purple
         }
 
+        const botInfo = (this.bot.handler as MyHandler).getBotInfo();
+
         /*eslint-disable */
         const webhook = JSON.stringify({
-            username: this.botName,
-            avatar_url: this.botAvatarURL,
+            username: process.env.DISCORD_WEBHOOK_USERNAME ? process.env.DISCORD_WEBHOOK_USERNAME : botInfo.name,
+            avatar_url: process.env.DISCORD_WEBHOOK_AVATAR_URL
+                ? process.env.DISCORD_WEBHOOK_AVATAR_URL
+                : botInfo.avatarURL,
             content: type === 'highValue' || type === 'highValuedDisabled' ? `<@!${this.ownerID}>` : '',
             embeds: [
                 {
@@ -144,10 +138,14 @@ export = class DiscordWebhookClass {
         steamREP: string,
         time: string
     ): void {
+        const botInfo = (this.bot.handler as MyHandler).getBotInfo();
+
         /*eslint-disable */
         const discordPartnerMsg = JSON.stringify({
-            username: this.botName,
-            avatar_url: this.botAvatarURL,
+            username: process.env.DISCORD_WEBHOOK_USERNAME ? process.env.DISCORD_WEBHOOK_USERNAME : botInfo.name,
+            avatar_url: process.env.DISCORD_WEBHOOK_AVATAR_URL
+                ? process.env.DISCORD_WEBHOOK_AVATAR_URL
+                : botInfo.avatarURL,
             content: `<@!${this.ownerID}>, new message! - ${steamID}`,
             embeds: [
                 {
@@ -207,8 +205,7 @@ export = class DiscordWebhookClass {
             }
         }
         const mentionOwner = noMentionOnInvalidValue ? `${offer.id}` : `<@!${this.ownerID}>, check this! - ${offer.id}`;
-        const botName = this.botName;
-        const botAvatarURL = this.botAvatarURL;
+        const botInfo = (this.bot.handler as MyHandler).getBotInfo();
         const botEmbedColor = this.botEmbedColor;
 
         const pureStock = (this.bot.handler as MyHandler).pureStock();
@@ -251,8 +248,10 @@ export = class DiscordWebhookClass {
 
             /*eslint-disable */
             const webhookReview = {
-                username: botName,
-                avatar_url: botAvatarURL,
+                username: process.env.DISCORD_WEBHOOK_USERNAME ? process.env.DISCORD_WEBHOOK_USERNAME : botInfo.name,
+                avatar_url: process.env.DISCORD_WEBHOOK_AVATAR_URL
+                    ? process.env.DISCORD_WEBHOOK_AVATAR_URL
+                    : botInfo.avatarURL,
                 content: mentionOwner,
                 embeds: [
                     {
@@ -389,8 +388,7 @@ export = class DiscordWebhookClass {
                 ? `<@!${this.ownerID}>`
                 : '';
 
-        const botName = this.botName;
-        const botAvatarURL = this.botAvatarURL;
+        const botInfo = (this.bot.handler as MyHandler).getBotInfo();
         const botEmbedColor = this.botEmbedColor;
 
         const tradeNumbertoShowStarter = parseInt(process.env.TRADES_MADE_STARTER_VALUE);
@@ -431,8 +429,10 @@ export = class DiscordWebhookClass {
 
             /*eslint-disable */
             const acceptedTradeSummary = {
-                username: botName,
-                avatar_url: botAvatarURL,
+                username: process.env.DISCORD_WEBHOOK_USERNAME ? process.env.DISCORD_WEBHOOK_USERNAME : botInfo.name,
+                avatar_url: process.env.DISCORD_WEBHOOK_AVATAR_URL
+                    ? process.env.DISCORD_WEBHOOK_AVATAR_URL
+                    : botInfo.avatarURL,
                 content: mentionOwner,
                 embeds: [
                     {
@@ -482,7 +482,7 @@ export = class DiscordWebhookClass {
                                     (AdditionalNotes
                                         ? (isShowKeyRate || isShowPureStock || isShowInventory ? '\n' : '') +
                                           AdditionalNotes
-                                        : '')
+                                        : `\n[View my backpack](https://backpack.tf/profiles/${botInfo.steamID})`)
                             }
                         ],
                         color: botEmbedColor

--- a/src/classes/DiscordWebhook.ts
+++ b/src/classes/DiscordWebhook.ts
@@ -100,6 +100,10 @@ export = class DiscordWebhookClass {
             title = 'Automatic restart failed - Error';
             description = `❌ An error occurred while trying to restart: ${err.message}`;
             color = '16711680'; // red
+        } else if (type === 'highValuedDisabled') {
+            title = 'Temporarily disabled items with High value attachments';
+            description = msg;
+            color = '8323327'; // purple
         } else {
             title = 'High Valued Items';
             description = `Someone is trying to take your **${items.join(', ')}** that is not in your pricelist.`;
@@ -110,7 +114,7 @@ export = class DiscordWebhookClass {
         const webhook = JSON.stringify({
             username: this.botName,
             avatar_url: this.botAvatarURL,
-            content: type === 'highValue' ? `<@!${this.ownerID}>` : '',
+            content: type === 'highValue' || type === 'highValuedDisabled' ? `<@!${this.ownerID}>` : '',
             embeds: [
                 {
                     title: title,

--- a/src/classes/DiscordWebhook.ts
+++ b/src/classes/DiscordWebhook.ts
@@ -36,7 +36,7 @@ export = class DiscordWebhookClass {
 
         let links = parseJSON(process.env.DISCORD_WEBHOOK_TRADE_SUMMARY_URL);
         if (links !== null && Array.isArray(links)) {
-            links.forEach(function(sku: string) {
+            links.forEach((sku: string) => {
                 if (sku === '' || !sku) {
                     links = [];
                 }
@@ -49,7 +49,7 @@ export = class DiscordWebhookClass {
 
         let skuFromEnv = parseJSON(process.env.DISCORD_WEBHOOK_TRADE_SUMMARY_MENTION_OWNER_ONLY_ITEMS_SKU);
         if (skuFromEnv !== null && Array.isArray(skuFromEnv)) {
-            skuFromEnv.forEach(function(sku: string) {
+            skuFromEnv.forEach((sku: string) => {
                 if (sku === '' || !sku) {
                     skuFromEnv = ['Not set'];
                 }
@@ -232,7 +232,7 @@ export = class DiscordWebhookClass {
         let partnerAvatar: string;
         let partnerName: string;
         log.debug('getting partner Avatar and Name...');
-        offer.getUserDetails(function(err, me, them) {
+        offer.getUserDetails((err, me, them) => {
             if (err) {
                 log.debug('Error retrieving partner Avatar and Name: ', err);
                 partnerAvatar =
@@ -358,14 +358,14 @@ export = class DiscordWebhookClass {
         const itemList = listItems(itemsName);
 
         // Mention owner on the sku(s) specified in DISCORD_WEBHOOK_TRADE_SUMMARY_MENTION_OWNER_ONLY_ITEMS_SKU
-        const isMentionOurItems = this.skuToMention.some((fromEnv: string) => {
-            return ourItems.some((ourItemSKU: string) => {
+        const isMentionOurItems = this.skuToMention.some(fromEnv => {
+            return ourItems.some(ourItemSKU => {
                 return ourItemSKU.includes(fromEnv);
             });
         });
 
-        const isMentionThierItems = this.skuToMention.some((fromEnv: string) => {
-            return theirItems.some((theirItemSKU: string) => {
+        const isMentionThierItems = this.skuToMention.some(fromEnv => {
+            return theirItems.some(theirItemSKU => {
                 return theirItemSKU.includes(fromEnv);
             });
         });
@@ -407,7 +407,7 @@ export = class DiscordWebhookClass {
         let personaName: string;
         let avatarFull: string;
         log.debug('getting partner Avatar and Name...');
-        this.getPartnerDetails(offer, function(err, details) {
+        this.getPartnerDetails(offer, (err, details) => {
             if (err) {
                 log.debug('Error retrieving partner Avatar and Name: ', err);
                 personaName = 'unknown';
@@ -529,7 +529,7 @@ export = class DiscordWebhookClass {
     private getPartnerDetails(offer: TradeOffer, callback: (err: any, details: any) => void): any {
         // check state of the offer
         if (offer.state === TradeOfferManager.ETradeOfferState.active) {
-            offer.getUserDetails(function(err, me, them) {
+            offer.getUserDetails((err, me, them) => {
                 if (err) {
                     callback(err, {});
                 } else {

--- a/src/classes/Friends.ts
+++ b/src/classes/Friends.ts
@@ -73,7 +73,10 @@ export = class Friends {
             gzip: true,
             qs: {
                 key: this.bot.manager.apiKey,
-                steamid: this.bot.client.steamID.getSteamID64()
+                steamid: (this.bot.client.steamID === null
+                    ? (this.bot.handler as MyHandler).getBotSteamID()
+                    : this.bot.client.steamID
+                ).getSteamID64()
             }
         };
 

--- a/src/classes/Inventory.ts
+++ b/src/classes/Inventory.ts
@@ -118,7 +118,7 @@ export = class Inventory {
         const tradable: EconItem[] = [];
         const nonTradable: EconItem[] = [];
 
-        items.forEach(function(item) {
+        items.forEach(item => {
             if (item.tradable) {
                 tradable.push(item);
             } else {

--- a/src/classes/Listings.ts
+++ b/src/classes/Listings.ts
@@ -134,7 +134,7 @@ export = class Listings {
                 json: true
             };
 
-            request(options, function(err, reponse, body) {
+            request(options, (err, reponse, body) => {
                 if (err) {
                     return reject(err);
                 }
@@ -234,7 +234,7 @@ export = class Listings {
             log.debug('Checking all');
 
             const doneRemovingAll = (): void => {
-                const next = callbackQueue.add('checkAllListings', function() {
+                const next = callbackQueue.add('checkAllListings', () => {
                     resolve();
                 });
 
@@ -303,7 +303,7 @@ export = class Listings {
             log.debug('Checking all');
 
             const doneRemovingAll = (): void => {
-                const next = callbackQueue.add('checkAllListings', function() {
+                const next = callbackQueue.add('checkAllListings', () => {
                     resolve();
                 });
 
@@ -372,7 +372,7 @@ export = class Listings {
             log.debug('Removing all listings');
 
             // Ensures that we don't to remove listings multiple times
-            const next = callbackQueue.add('removeAllListings', function(err) {
+            const next = callbackQueue.add('removeAllListings', err => {
                 if (err) {
                     return reject(err);
                 }

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -157,7 +157,7 @@ export = class MyHandler extends Handler {
                 noiseEnabled: process.env.DISABLE_CHECK_USES_NOISE_MAKER === 'false'
             },
             acceptGiftNoNotes: {
-                enabled: process.env.ALLOW_GIFT_WITHOUT_NOTE === 'false'
+                enabled: process.env.ALLOW_GIFT_WITHOUT_NOTE === 'true'
             },
             autoRemoveIntentSell: process.env.DISABLE_AUTO_REMOVE_INTENT_SELL !== 'true', // By default it will remove pricelist entry with intent=sell, unless this is set to true
             givePrice: process.env.DISABLE_GIVE_PRICE_TO_INVALID_ITEMS === 'false',

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -57,44 +57,6 @@ export = class MyHandler extends Handler {
 
     private hasInvalidValueException = false;
 
-    private fromEnv: {
-        autoAcceptOverpay: {
-            invalidItem: boolean;
-            overstocked: boolean;
-            understocked: boolean;
-        };
-        autoDecline: {
-            invalidValue: boolean;
-            overstocked: boolean;
-            understocked: boolean;
-        };
-        somethingWrong: {
-            enabled: boolean;
-            url: string;
-        };
-        tradeSummaryWebhook: {
-            enabled: boolean;
-            url: string;
-        };
-        reviewOfferWebhook: {
-            enabled: boolean;
-            url: string;
-        };
-        checkUses: {
-            duelEnabled: boolean;
-            noiseEnabled: boolean;
-        };
-        acceptGiftNoNotes: {
-            enabled: boolean;
-        };
-        autoRemoveIntentSell: boolean;
-        givePrice: boolean;
-        craftWeaponAsCurrency: boolean;
-        showMetal: boolean;
-        autokeysNotAcceptUnderstocked: boolean;
-        onlyTF2: boolean;
-    };
-
     private isTradingKeys = false;
 
     private customGameName: string;
@@ -137,49 +99,11 @@ export = class MyHandler extends Handler {
         const minimumReclaimed = parseInt(process.env.MINIMUM_RECLAIMED);
         const combineThreshold = parseInt(process.env.METAL_THRESHOLD);
 
-        this.fromEnv = {
-            autoAcceptOverpay: {
-                invalidItem: process.env.DISABLE_ACCEPT_INVALID_ITEMS_OVERPAY !== 'true',
-                overstocked: process.env.DISABLE_ACCEPT_OVERSTOCKED_OVERPAY === 'false',
-                understocked: process.env.DISABLE_ACCEPT_UNDERSTOCKED_OVERPAY === 'false'
-            },
-            autoDecline: {
-                invalidValue: process.env.DISABLE_AUTO_DECLINE_INVALID_VALUE !== 'true',
-                overstocked: process.env.DISABLE_AUTO_DECLINE_OVERSTOCKED === 'false',
-                understocked: process.env.DISABLE_AUTO_DECLINE_UNDERSTOCKED === 'false'
-            },
-            somethingWrong: {
-                enabled: process.env.DISABLE_DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT === 'false',
-                url: process.env.DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT_URL
-            },
-            tradeSummaryWebhook: {
-                enabled: process.env.DISABLE_DISCORD_WEBHOOK_TRADE_SUMMARY === 'false',
-                url: process.env.DISCORD_WEBHOOK_TRADE_SUMMARY_URL
-            },
-            reviewOfferWebhook: {
-                enabled: process.env.DISABLE_DISCORD_WEBHOOK_OFFER_REVIEW === 'false',
-                url: process.env.DISCORD_WEBHOOK_REVIEW_OFFER_URL
-            },
-            checkUses: {
-                duelEnabled: process.env.DISABLE_CHECK_USES_DUELING_MINI_GAME === 'false',
-                noiseEnabled: process.env.DISABLE_CHECK_USES_NOISE_MAKER === 'false'
-            },
-            acceptGiftNoNotes: {
-                enabled: process.env.ALLOW_GIFT_WITHOUT_NOTE === 'true'
-            },
-            autoRemoveIntentSell: process.env.DISABLE_AUTO_REMOVE_INTENT_SELL !== 'true', // By default it will remove pricelist entry with intent=sell, unless this is set to true
-            givePrice: process.env.DISABLE_GIVE_PRICE_TO_INVALID_ITEMS === 'false',
-            craftWeaponAsCurrency: process.env.DISABLE_CRAFTWEAPON_AS_CURRENCY !== 'true',
-            showMetal: process.env.ENABLE_SHOW_ONLY_METAL === 'true',
-            autokeysNotAcceptUnderstocked: process.env.AUTOKEYS_ACCEPT_UNDERSTOCKED !== 'true',
-            onlyTF2: process.env.ENABLE_ONLY_PLAY_TF2 === 'true'
-        };
-
         const exceptionRef = parseInt(process.env.INVALID_VALUE_EXCEPTION_VALUE_IN_REF);
 
         let invalidValueExceptionSKU = parseJSON(process.env.INVALID_VALUE_EXCEPTION_SKUS);
         if (invalidValueExceptionSKU !== null && Array.isArray(invalidValueExceptionSKU)) {
-            invalidValueExceptionSKU.forEach(function(sku: string) {
+            invalidValueExceptionSKU.forEach((sku: string) => {
                 if (sku === '' || !sku) {
                     invalidValueExceptionSKU = ['Not Set'];
                 }
@@ -233,7 +157,7 @@ export = class MyHandler extends Handler {
 
         const groups = parseJSON(process.env.GROUPS);
         if (groups !== null && Array.isArray(groups)) {
-            groups.forEach(function(groupID64) {
+            groups.forEach(groupID64 => {
                 if (!new SteamID(groupID64).isValid()) {
                     throw new Error(`Invalid group SteamID64 "${groupID64}"`);
                 }
@@ -244,7 +168,7 @@ export = class MyHandler extends Handler {
 
         const friendsToKeep = parseJSON(process.env.KEEP).concat(this.bot.getAdmins());
         if (friendsToKeep !== null && Array.isArray(friendsToKeep)) {
-            friendsToKeep.forEach(function(steamID64) {
+            friendsToKeep.forEach(steamID64 => {
                 if (!new SteamID(steamID64).isValid()) {
                     throw new Error(`Invalid SteamID64 "${steamID64}"`);
                 }
@@ -308,7 +232,7 @@ export = class MyHandler extends Handler {
             files.readFile(paths.files.pricelist, true),
             files.readFile(paths.files.loginAttempts, true),
             files.readFile(paths.files.pollData, true)
-        ]).then(function([loginKey, pricelist, loginAttempts, pollData]) {
+        ]).then(([loginKey, pricelist, loginAttempts, pollData]) => {
             return { loginKey, pricelist, loginAttempts, pollData };
         });
     }
@@ -326,7 +250,7 @@ export = class MyHandler extends Handler {
                 ')'
         );
 
-        this.bot.client.gamesPlayed(this.fromEnv.onlyTF2 ? 440 : [this.customGameName, 440]);
+        this.bot.client.gamesPlayed(process.env.ENABLE_ONLY_PLAY_TF2 === 'true' ? 440 : [this.customGameName, 440]);
         this.bot.client.setPersona(SteamUser.EPersonaState.Online);
 
         // Get Backpack slots and Premium info from backpack.tf
@@ -385,7 +309,7 @@ export = class MyHandler extends Handler {
                 this.autokeys.disable();
             }
 
-            this.bot.listings.removeAll().asCallback(function(err) {
+            this.bot.listings.removeAll().asCallback(err => {
                 if (err) {
                     log.warn('Failed to remove all listings: ', err);
                 }
@@ -398,7 +322,7 @@ export = class MyHandler extends Handler {
     onLoggedOn(): void {
         if (this.bot.isReady()) {
             this.bot.client.setPersona(SteamUser.EPersonaState.Online);
-            this.bot.client.gamesPlayed(this.fromEnv.onlyTF2 ? 440 : [this.customGameName, 440]);
+            this.bot.client.gamesPlayed(process.env.ENABLE_ONLY_PLAY_TF2 === 'true' ? 440 : [this.customGameName, 440]);
         }
     }
 
@@ -429,7 +353,7 @@ export = class MyHandler extends Handler {
     onLoginKey(loginKey: string): void {
         log.debug('New login key');
 
-        files.writeFile(paths.files.loginKey, loginKey, false).catch(function(err) {
+        files.writeFile(paths.files.loginKey, loginKey, false).catch(err => {
             log.warn('Failed to save login key: ', err);
         });
     }
@@ -444,7 +368,7 @@ export = class MyHandler extends Handler {
     }
 
     onLoginAttempts(attempts: number[]): void {
-        files.writeFile(paths.files.loginAttempts, attempts, true).catch(function(err) {
+        files.writeFile(paths.files.loginAttempts, attempts, true).catch(err => {
             log.warn('Failed to save login attempts: ', err);
         });
     }
@@ -583,8 +507,6 @@ export = class MyHandler extends Handler {
 
         // Always check if trade partner is taking higher value items (such as spelled or strange parts) that are not in our pricelist
 
-        const webhook = this.fromEnv.tradeSummaryWebhook;
-
         let hasHighValueOur = false;
         const highValuedOur: {
             skus: string[];
@@ -674,7 +596,10 @@ export = class MyHandler extends Handler {
 
                 log.debug('info', `${itemName} (${item.assetid})${spellOrParts}`);
 
-                if (webhook.enabled && webhook.url) {
+                if (
+                    process.env.DISABLE_DISCORD_WEBHOOK_TRADE_SUMMARY === 'false' &&
+                    process.env.DISCORD_WEBHOOK_TRADE_SUMMARY_URL
+                ) {
                     highValuedOur.nameWithSpellsOrParts.push(
                         `[${itemName}](https://backpack.tf/item/${item.assetid})${spellOrParts}`
                     );
@@ -755,7 +680,10 @@ export = class MyHandler extends Handler {
 
                 log.debug('info', `${itemName} (${item.assetid})${spellOrParts}`);
 
-                if (webhook.enabled && webhook.url) {
+                if (
+                    process.env.DISABLE_DISCORD_WEBHOOK_TRADE_SUMMARY === 'false' &&
+                    process.env.DISCORD_WEBHOOK_TRADE_SUMMARY_URL
+                ) {
                     highValuedTheir.nameWithSpellsOrParts.push(
                         `[${itemName}](https://backpack.tf/item/${item.assetid})${spellOrParts}`
                     );
@@ -815,7 +743,7 @@ export = class MyHandler extends Handler {
                 }
             };
         } else if (offer.itemsToGive.length === 0 && offer.itemsToReceive.length > 0 && !isGift) {
-            if (this.fromEnv.acceptGiftNoNotes.enabled) {
+            if (process.env.ALLOW_GIFT_WITHOUT_NOTE === 'true') {
                 offer.log(
                     'info',
                     'is a gift offer without any offer message, but allowed to be accepted, accepting...'
@@ -848,7 +776,10 @@ export = class MyHandler extends Handler {
 
         const checkExist = this.bot.pricelist;
 
-        if (this.fromEnv.checkUses.duelEnabled || this.fromEnv.checkUses.noiseEnabled) {
+        if (
+            process.env.DISABLE_CHECK_USES_DUELING_MINI_GAME === 'false' ||
+            process.env.DISABLE_CHECK_USES_NOISE_MAKER === 'false'
+        ) {
             let hasNot5Uses = false;
             let hasNot25Uses = false;
             const noiseMakerSKU: string[] = [];
@@ -859,7 +790,7 @@ export = class MyHandler extends Handler {
                     return item.market_hash_name.includes(name);
                 });
 
-                if (isDuelingMiniGame && this.fromEnv.checkUses.duelEnabled) {
+                if (isDuelingMiniGame && process.env.DISABLE_CHECK_USES_DUELING_MINI_GAME === 'false') {
                     // Check for Dueling Mini-Game for 5x Uses only when enabled
                     for (let i = 0; i < item.descriptions.length; i++) {
                         const descriptionValue = item.descriptions[i].value;
@@ -874,7 +805,7 @@ export = class MyHandler extends Handler {
                             break;
                         }
                     }
-                } else if (isNoiseMaker && this.fromEnv.checkUses.noiseEnabled) {
+                } else if (isNoiseMaker && process.env.DISABLE_CHECK_USES_NOISE_MAKER === 'false') {
                     // Check for Noise Maker for 25x Uses only when enabled
                     for (let i = 0; i < item.descriptions.length; i++) {
                         const descriptionValue = item.descriptions[i].value;
@@ -923,7 +854,10 @@ export = class MyHandler extends Handler {
             offer.log('info', 'contains higher value item on our side that is not in our pricelist.');
 
             // Inform admin via Steam Chat or Discord Webhook Something Wrong Alert.
-            if (this.fromEnv.somethingWrong.enabled && this.fromEnv.somethingWrong.url) {
+            if (
+                process.env.DISABLE_DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT === 'false' &&
+                process.env.DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT_URL
+            ) {
                 this.discord.sendAlert('highValue', null, null, null, highValuedOur.nameWithSpellsOrParts);
             } else {
                 this.bot.messageAdmins(
@@ -1035,7 +969,7 @@ export = class MyHandler extends Handler {
                     exchange[which].scrap += value;
                 } else if (
                     (craft.includes(sku) || uncraft.includes(sku)) &&
-                    this.fromEnv.craftWeaponAsCurrency &&
+                    process.env.DISABLE_CRAFTWEAPON_AS_CURRENCY !== 'true' &&
                     this.bot.pricelist.getPrice(sku, true) === null
                 ) {
                     const value = 0.5 * amount;
@@ -1043,9 +977,10 @@ export = class MyHandler extends Handler {
                     exchange[which].scrap += value;
                 } else {
                     const match = this.bot.pricelist.getPrice(sku, true);
-                    const notIncludeCraftweapon = this.fromEnv.craftWeaponAsCurrency
-                        ? !(craft.includes(sku) || uncraft.includes(sku))
-                        : true;
+                    const notIncludeCraftweapon =
+                        process.env.DISABLE_CRAFTWEAPON_AS_CURRENCY !== 'true'
+                            ? !(craft.includes(sku) || uncraft.includes(sku))
+                            : true;
 
                     // TODO: Go through all assetids and check if the item is being sold for a specific price
 
@@ -1146,7 +1081,11 @@ export = class MyHandler extends Handler {
                             price.buy = new Currencies(price.buy);
                             price.sell = new Currencies(price.sell);
 
-                            if (this.fromEnv.givePrice && item.wear === null && isCanBePriced) {
+                            if (
+                                process.env.DISABLE_GIVE_PRICE_TO_INVALID_ITEMS === 'false' &&
+                                item.wear === null &&
+                                isCanBePriced
+                            ) {
                                 // if DISABLE_GIVE_PRICE_TO_INVALID_ITEMS is set to false (enable) and items is not skins/war paint,
                                 // and the item is not enabled=false,
                                 // then give that item price and include in exchange
@@ -1179,7 +1118,7 @@ export = class MyHandler extends Handler {
         }
 
         // Doing this so that the prices will always be displayed as only metal
-        if (this.fromEnv.showMetal) {
+        if (process.env.ENABLE_SHOW_ONLY_METAL === 'true') {
             exchange.our.scrap += exchange.our.keys * keyPrice.toValue();
             exchange.our.keys = 0;
             exchange.their.scrap += exchange.their.keys * keyPrice.toValue();
@@ -1247,7 +1186,7 @@ export = class MyHandler extends Handler {
                     this.bot.listings.checkBySKU('5021;6');
                 }
 
-                const isNotAcceptUnderstocked = this.fromEnv.autokeysNotAcceptUnderstocked;
+                const isNotAcceptUnderstocked = process.env.AUTOKEYS_ACCEPT_UNDERSTOCKED !== 'true';
 
                 if (diff !== 0 && !isBuying && amountCanTrade < Math.abs(diff) && isNotAcceptUnderstocked) {
                     // User is taking too many
@@ -1271,14 +1210,14 @@ export = class MyHandler extends Handler {
         const ourItemsSKU = itemsList.our;
         const theirItemsSKU = itemsList.their;
 
-        const isOurItems = exceptionSKU.some((fromEnv: string) => {
-            return ourItemsSKU.some((ourItemSKU: string) => {
+        const isOurItems = exceptionSKU.some(fromEnv => {
+            return ourItemsSKU.some(ourItemSKU => {
                 return ourItemSKU.includes(fromEnv);
             });
         });
 
-        const isThierItems = exceptionSKU.some((fromEnv: string) => {
-            return theirItemsSKU.some((theirItemSKU: string) => {
+        const isThierItems = exceptionSKU.some(fromEnv => {
+            return theirItemsSKU.some(theirItemSKU => {
                 return theirItemSKU.includes(fromEnv);
             });
         });
@@ -1429,7 +1368,7 @@ export = class MyHandler extends Handler {
             const requests = assetidsToCheck.map(assetid => {
                 return (callback: (err: Error | null, result: boolean | null) => void): void => {
                     log.debug('Dupe checking ' + assetid + '...');
-                    Promise.resolve(inventory.isDuped(assetid)).asCallback(function(err, result) {
+                    Promise.resolve(inventory.isDuped(assetid)).asCallback((err, result) => {
                         log.debug('Dupe check for ' + assetid + ' done');
                         callback(err, result);
                     });
@@ -1437,7 +1376,7 @@ export = class MyHandler extends Handler {
             });
 
             try {
-                const result: (boolean | null)[] = await Promise.fromCallback(function(callback) {
+                const result: (boolean | null)[] = await Promise.fromCallback(callback => {
                     async.series(requests, callback);
                 });
 
@@ -1499,11 +1438,9 @@ export = class MyHandler extends Handler {
             const isDupedItem = uniqueReasons.includes('🟫_DUPED_ITEMS');
             const isDupedCheckFailed = uniqueReasons.includes('🟪_DUPE_CHECK_FAILED');
 
-            const env = this.fromEnv;
-
-            const canAcceptInvalidItemsOverpay = env.autoAcceptOverpay.invalidItem;
-            const canAcceptOverstockedOverpay = env.autoAcceptOverpay.overstocked;
-            const canAcceptUnderstockedOverpay = env.autoAcceptOverpay.understocked;
+            const canAcceptInvalidItemsOverpay = process.env.DISABLE_ACCEPT_INVALID_ITEMS_OVERPAY !== 'true';
+            const canAcceptOverstockedOverpay = process.env.DISABLE_ACCEPT_OVERSTOCKED_OVERPAY === 'false';
+            const canAcceptUnderstockedOverpay = process.env.DISABLE_ACCEPT_UNDERSTOCKED_OVERPAY === 'false';
 
             // accepting 🟨_INVALID_ITEMS overpay
 
@@ -1581,7 +1518,7 @@ export = class MyHandler extends Handler {
                     }
                 };
             } else if (
-                env.autoDecline.invalidValue &&
+                process.env.DISABLE_AUTO_DECLINE_INVALID_VALUE !== 'true' &&
                 isInvalidValue &&
                 !(isUnderstocked || isInvalidItem || isOverstocked || isDupedItem || isDupedCheckFailed) &&
                 this.hasInvalidValueException === false
@@ -1589,14 +1526,14 @@ export = class MyHandler extends Handler {
                 // If only INVALID_VALUE and did not matched exception value, will just decline the trade.
                 return { action: 'decline', reason: 'ONLY_INVALID_VALUE' };
             } else if (
-                env.autoDecline.overstocked &&
+                process.env.DISABLE_AUTO_DECLINE_OVERSTOCKED === 'false' &&
                 isOverstocked &&
                 !(isInvalidItem || isDupedItem || isDupedCheckFailed)
             ) {
                 // If only OVERSTOCKED and Auto-decline OVERSTOCKED enabled, will just decline the trade.
                 return { action: 'decline', reason: 'ONLY_OVERSTOCKED' };
             } else if (
-                env.autoDecline.understocked &&
+                process.env.DISABLE_AUTO_DECLINE_UNDERSTOCKED === 'false' &&
                 isUnderstocked &&
                 !(isInvalidItem || isDupedItem || isDupedCheckFailed)
             ) {
@@ -2139,7 +2076,10 @@ export = class MyHandler extends Handler {
                                 }
                             }
 
-                            if (this.fromEnv.somethingWrong.enabled && this.fromEnv.somethingWrong.url) {
+                            if (
+                                process.env.DISABLE_DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT === 'false' &&
+                                process.env.DISCORD_WEBHOOK_SOMETHING_WRONG_ALERT_URL
+                            ) {
                                 this.discord.sendAlert('highValuedDisabled', msg.replace(/"/g, '`'), null, null, null);
                             } else {
                                 this.bot.messageAdmins(msg, []);
@@ -2149,7 +2089,7 @@ export = class MyHandler extends Handler {
                             log.warn(`❌ Failed to disable high value ${sku}: ${err.message}`);
                         });
                 } else if (
-                    this.fromEnv.autoRemoveIntentSell &&
+                    process.env.DISABLE_AUTO_REMOVE_INTENT_SELL !== 'true' &&
                     inPrice !== null &&
                     inPrice.intent === 1 &&
                     currentStock < 1
@@ -2279,7 +2219,10 @@ export = class MyHandler extends Handler {
 
                 duped.forEach(el => {
                     const name = this.bot.schema.getName(SKU.fromString(el.sku), false);
-                    if (this.fromEnv.reviewOfferWebhook.enabled && this.fromEnv.reviewOfferWebhook.url) {
+                    if (
+                        process.env.DISABLE_DISCORD_WEBHOOK_OFFER_REVIEW === 'false' &&
+                        process.env.DISCORD_WEBHOOK_REVIEW_OFFER_URL
+                    ) {
                         // if Discord Webhook for review offer enabled, then make it link the item name to the backpack.tf item history page.
                         dupedItemsName.push(`${name} - [history page](https://backpack.tf/item/${el.assetid})`);
                     } else {
@@ -2312,7 +2255,10 @@ export = class MyHandler extends Handler {
                         // If 🟪_DUPE_CHECK_FAILED occurred without error, then this sku/assetid is string.
                         const name = this.bot.schema.getName(SKU.fromString(el.sku), false);
 
-                        if (this.fromEnv.reviewOfferWebhook.enabled && this.fromEnv.reviewOfferWebhook.url) {
+                        if (
+                            process.env.DISABLE_DISCORD_WEBHOOK_OFFER_REVIEW === 'false' &&
+                            process.env.DISCORD_WEBHOOK_REVIEW_OFFER_URL
+                        ) {
                             // if Discord Webhook for review offer enabled, then make it link the item name to the backpack.tf item history page.
                             dupedFailedItemsName.push(
                                 `${name} - [history page](https://backpack.tf/item/${el.assetid})`
@@ -2326,7 +2272,10 @@ export = class MyHandler extends Handler {
                         for (let i = 0; i < el.sku.length; i++) {
                             const name = this.bot.schema.getName(SKU.fromString(el.sku[i]), false);
 
-                            if (this.fromEnv.reviewOfferWebhook.enabled && this.fromEnv.reviewOfferWebhook.url) {
+                            if (
+                                process.env.DISABLE_DISCORD_WEBHOOK_OFFER_REVIEW === 'false' &&
+                                process.env.DISCORD_WEBHOOK_REVIEW_OFFER_URL
+                            ) {
                                 // if Discord Webhook for review offer enabled, then make it link the item name to the backpack.tf item history page.
                                 dupedFailedItemsName.push(
                                     `${name} - [history page](https://backpack.tf/item/${el.assetid})`
@@ -2834,7 +2783,7 @@ export = class MyHandler extends Handler {
         this.bot.getAdmins().forEach(steamID => {
             if (!this.bot.friends.isFriend(steamID)) {
                 log.info(`Not friends with admin ${steamID}, sending friend request...`);
-                this.bot.client.addFriend(steamID, function(err) {
+                this.bot.client.addFriend(steamID, err => {
                     if (err) {
                         log.warn('Failed to send friend request: ', err);
                     }
@@ -2848,7 +2797,7 @@ export = class MyHandler extends Handler {
 
         log.debug(`Sending friend request to ${steamID64}...`);
 
-        this.bot.client.addFriend(steamID, function(err) {
+        this.bot.client.addFriend(steamID, err => {
             if (err) {
                 log.warn(`Failed to send friend request to ${steamID64}: `, err);
                 return;
@@ -2932,7 +2881,7 @@ export = class MyHandler extends Handler {
             const friendsWithTrades = this.bot.trades.getTradesWithPeople(friends);
 
             // Ignore friends to keep
-            this.friendsToKeep.forEach(function(steamID) {
+            this.friendsToKeep.forEach(steamID => {
                 delete friendsWithTrades[steamID];
             });
 
@@ -3104,7 +3053,7 @@ export = class MyHandler extends Handler {
                 }
             };
 
-            if (!this.fromEnv.showMetal) {
+            if (!(process.env.ENABLE_SHOW_ONLY_METAL === 'true')) {
                 // if ENABLE_SHOW_ONLY_METAL is set to false, then this need to be converted first.
                 if (this.isTradingKeys) {
                     // If trading keys, then their side need to use buying key price.
@@ -3779,14 +3728,14 @@ export = class MyHandler extends Handler {
                 this.bot.client.myGroups[steamID] !== SteamUser.EClanRelationship.Member &&
                 this.bot.client.myGroups[steamID] !== SteamUser.EClanRelationship.Blocked
             ) {
-                this.bot.community.getSteamGroup(new SteamID(steamID), function(err, group) {
+                this.bot.community.getSteamGroup(new SteamID(steamID), (err, group) => {
                     if (err) {
                         log.warn('Failed to get group: ', err);
                         return;
                     }
 
                     log.info(`Not member of group ${group.name} ("${steamID}"), joining...`);
-                    group.join(function(err) {
+                    group.join(err => {
                         if (err) {
                             log.warn('Failed to join group: ', err);
                         }
@@ -3797,7 +3746,7 @@ export = class MyHandler extends Handler {
     }
 
     onPollData(pollData: PollData): void {
-        files.writeFile(paths.files.pollData, pollData, true).catch(function(err) {
+        files.writeFile(paths.files.pollData, pollData, true).catch(err => {
             log.warn('Failed to save polldata: ', err);
         });
     }
@@ -3816,7 +3765,7 @@ export = class MyHandler extends Handler {
                 pricelist.map(entry => entry.getJSON()),
                 true
             )
-            .catch(function(err) {
+            .catch(err => {
                 log.warn('Failed to save pricelist: ', err);
             });
     }
@@ -3831,7 +3780,7 @@ export = class MyHandler extends Handler {
 
     onTF2QueueCompleted(): void {
         log.debug('Queue finished');
-        this.bot.client.gamesPlayed(this.fromEnv.onlyTF2 ? 440 : [this.customGameName, 440]);
+        this.bot.client.gamesPlayed(process.env.ENABLE_ONLY_PLAY_TF2 === 'true' ? 440 : [this.customGameName, 440]);
     }
 };
 

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -103,6 +103,10 @@ export = class MyHandler extends Handler {
 
     private isPremium = false;
 
+    private botName = '';
+
+    private botAvatarURL = '';
+
     private retryRequest;
 
     private autokeysStatus: {
@@ -128,8 +132,6 @@ export = class MyHandler extends Handler {
         this.autokeys = new Autokeys(bot);
 
         this.uptime = moment().valueOf();
-
-        this.botSteamID = this.bot.client.steamID;
 
         const minimumScrap = parseInt(process.env.MINIMUM_SCRAP);
         const minimumReclaimed = parseInt(process.env.MINIMUM_RECLAIMED);
@@ -280,6 +282,13 @@ export = class MyHandler extends Handler {
         return this.backpackSlots;
     }
 
+    getBotInfo(): { name: string; avatarURL: string; steamID: string } {
+        const name = this.botName;
+        const avatarURL = this.botAvatarURL;
+        const steamID = this.botSteamID.toString();
+        return { name, avatarURL, steamID };
+    }
+
     getAutokeysStatus(): { isActive: boolean; isBuying: boolean; isBanking: boolean } {
         return this.autokeysStatus;
     }
@@ -355,6 +364,8 @@ export = class MyHandler extends Handler {
 
         // Set up autorelist if enabled in environment variable
         this.bot.listings.setupAutorelist();
+
+        this.botSteamID = this.bot.client.steamID;
 
         // Check for missing sell listings every 5 minutes, 30 minutes after start
         setTimeout(() => {
@@ -3037,6 +3048,8 @@ export = class MyHandler extends Handler {
 
                     this.isPremium = isPremium;
                     this.backpackSlots = user.inventory['440'].slots.total;
+                    this.botName = user.name;
+                    this.botAvatarURL = user.avatar;
 
                     return resolve();
                 }

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1645,6 +1645,7 @@ export = class MyHandler extends Handler {
 
         let hasHighValueOur = false;
         let hasHighValueTheir = false;
+        const theirHighValuedItems: string[] = [];
 
         const handledByUs = offer.data('handledByUs') === true;
         const notify = offer.data('notify') === true;
@@ -1879,6 +1880,7 @@ export = class MyHandler extends Handler {
                             // doing this to check if their side have any high value items, if so, push each name into accepted.highValue const.
                             offerMeta.meta.highValueItems.their.nameWithSpellsOrParts.forEach(name => {
                                 accepted.highValue.push(name);
+                                theirHighValuedItems.push(name);
                             });
                         }
 
@@ -1896,6 +1898,7 @@ export = class MyHandler extends Handler {
                         hasHighValueTheir = true;
                         offerMade.nameWithSpellsOrParts.forEach(name => {
                             accepted.highValue.push(name);
+                            theirHighValuedItems.push(name);
                         });
                     }
                 }
@@ -2089,6 +2092,24 @@ export = class MyHandler extends Handler {
                         .updatePrice(entry as EntryData, true)
                         .then(() => {
                             log.debug(`✅ Automatically disabled ${sku}, which is a high value item.`);
+
+                            let msg =
+                                `I have temporarily disabled ${name} (${sku}) because it contains some high value spells/parts.` +
+                                `\nYou can manually price it with "!update sku=${sku}&enabled=true&<buy and sell price>"` +
+                                ` or just re-enable it with "!update sku=${sku}&enabled=true".` +
+                                '\n\nItem information:\n\n- ';
+
+                            for (let i = 0; i < theirHighValuedItems.length; i++) {
+                                if (theirHighValuedItems[i].includes(name)) {
+                                    msg += theirHighValuedItems[i];
+                                }
+                            }
+
+                            if (this.fromEnv.somethingWrong.enabled && this.fromEnv.somethingWrong.url) {
+                                this.discord.sendAlert('highValuedDisabled', msg.replace(/"/g, '`'), null, null, null);
+                            } else {
+                                this.bot.messageAdmins(msg, []);
+                            }
                         })
                         .catch(err => {
                             log.warn(`❌ Failed to disable high value ${sku}: ${err.message}`);

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -113,6 +113,8 @@ export = class MyHandler extends Handler {
 
     private uptime: number;
 
+    private botSteamID: SteamID;
+
     recentlySentMessage: UnknownDictionary<number> = {};
 
     constructor(bot: Bot) {
@@ -124,6 +126,8 @@ export = class MyHandler extends Handler {
         this.autokeys = new Autokeys(bot);
 
         this.uptime = moment().valueOf();
+
+        this.botSteamID = this.bot.client.steamID;
 
         const minimumScrap = parseInt(process.env.MINIMUM_SCRAP);
         const minimumReclaimed = parseInt(process.env.MINIMUM_RECLAIMED);
@@ -252,6 +256,10 @@ export = class MyHandler extends Handler {
 
     getFriendToKeep(): number {
         return this.friendsToKeep.length;
+    }
+
+    getBotSteamID(): SteamID {
+        return this.botSteamID;
     }
 
     hasDupeCheckEnabled(): boolean {
@@ -492,7 +500,7 @@ export = class MyHandler extends Handler {
         clearTimeout(this.classWeaponsTimeout);
 
         const ourItems = Inventory.fromItems(
-            this.bot.client.steamID,
+            this.bot.client.steamID === null ? this.botSteamID : this.bot.client.steamID,
             offer.itemsToGive,
             this.bot.manager,
             this.bot.schema
@@ -2916,7 +2924,10 @@ export = class MyHandler extends Handler {
                     method: 'GET',
                     qs: {
                         key: this.bot.manager.apiKey,
-                        steamid: this.bot.client.steamID.getSteamID64()
+                        steamid: (this.bot.client.steamID === null
+                            ? this.botSteamID
+                            : this.bot.client.steamID
+                        ).getSteamID64()
                     },
                     json: true,
                     gzip: true

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1984,10 +1984,10 @@ export = class MyHandler extends Handler {
             const diffTime = now - this.uptime;
 
             const printTime =
-                diffTime >= 77400 * 1000 && diffTime < 127800 * 1000 // 21.5 h - 35.5 hours will show "a day", so show hours in bracket.
-                    ? ' (' + Math.round((diffTime / 3600) * 1000) + ' hours)'
-                    : diffTime >= 2203200 * 1000 // More than 25.5 days, will become "a month", so show how many days in bracket.
-                    ? ' (' + Math.round((diffTime / 86400) * 1000) + ' days)'
+                diffTime >= 21.5 * 60 * 60 * 1000 && diffTime < 35.5 * 60 * 60 * 1000 // 21.5 h - 35.5 hours will show "a day", so show hours in bracket.
+                    ? ' (' + Math.round(diffTime / (1 * 60 * 60 * 1000)) + ' hours)'
+                    : diffTime >= 25.5 * 24 * 60 * 60 * 1000 // More than 25.5 days, will become "a month", so show how many days in bracket.
+                    ? ' (' + Math.round(diffTime / (1 * 24 * 60 * 60 * 1000)) + ' days)'
                     : '';
 
             log.debug(`Bot has been up for ${moment(this.uptime).fromNow(true) + printTime}.`);

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -2989,11 +2989,14 @@ export = class MyHandler extends Handler {
                 },
                 (err, reponse, body) => {
                     if (err) {
+                        log.debug('Failed requesting bot info from backpack.tf, retrying in 5 minutes: ', err);
                         clearTimeout(this.retryRequest);
+
                         this.retryRequest = setTimeout(() => {
                             this.getBPTFAccountInfo();
                         }, 5 * 60 * 1000);
-                        return reject(err);
+
+                        return reject();
                     }
 
                     const user = body.users[steamID64];

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1112,6 +1112,14 @@ export = class MyHandler extends Handler {
 
                         const item = SKU.fromString(sku);
 
+                        // "match" will return null if the item is not enabled
+                        // define "recheckMatch" with onlyEnabled = false
+                        const recheckMatch = this.bot.pricelist.getPrice(sku, false);
+
+                        // If recheckMatch is not null, then check the enabled key (most likely false here),
+                        // else means the item is truly not in pricelist and make "isCanBePriced" true
+                        const isCanBePriced = recheckMatch !== null ? recheckMatch.enabled : true;
+
                         let itemSuggestedValue;
 
                         if (price === null) {
@@ -1121,8 +1129,9 @@ export = class MyHandler extends Handler {
                             price.buy = new Currencies(price.buy);
                             price.sell = new Currencies(price.sell);
 
-                            if (this.fromEnv.givePrice && item.wear === null) {
+                            if (this.fromEnv.givePrice && item.wear === null && isCanBePriced) {
                                 // if DISABLE_GIVE_PRICE_TO_INVALID_ITEMS is set to false (enable) and items is not skins/war paint,
+                                // and the item is not enabled=false,
                                 // then give that item price and include in exchange
                                 exchange[which].value += price[intentString].toValue(keyPrice.metal) * amount;
                                 exchange[which].keys += price[intentString].keys * amount;

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -826,6 +826,7 @@ export = class MyHandler extends Handler {
         if (this.fromEnv.checkUses.duelEnabled || this.fromEnv.checkUses.noiseEnabled) {
             let hasNot5Uses = false;
             let hasNot25Uses = false;
+            const noiseMakerSKU: string[] = [];
 
             offer.itemsToReceive.forEach(item => {
                 const isDuelingMiniGame = item.market_hash_name === 'Dueling Mini-Game';
@@ -859,6 +860,8 @@ export = class MyHandler extends Handler {
                             descriptionColor === '00a000'
                         ) {
                             hasNot25Uses = true;
+                            noiseMakerSKU.push(item.getSKU(this.bot.schema));
+
                             log.debug('info', `${item.market_hash_name} (${item.assetid}) is not 25 uses.`);
                             break;
                         }
@@ -872,7 +875,7 @@ export = class MyHandler extends Handler {
                 return { action: 'decline', reason: 'DUELING_NOT_5_USES' };
             }
 
-            const isHasNoiseMaker = this.noiseMakerSKUs().some(sku => {
+            const isHasNoiseMaker = noiseMakerSKU.some(sku => {
                 return checkExist.getPrice(sku, true) !== null;
             });
 

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -2044,7 +2044,15 @@ export = class MyHandler extends Handler {
                                     (err.body && err.body.message ? err.body.message : err.message)
                             );
                         } else {
-                            log.debug(`✅ Requested pricecheck for ${body.name} (${sku}).`);
+                            log.debug(
+                                `✅ Requested pricecheck for ${
+                                    body.name.includes('War Paint') ||
+                                    body.name.includes('Mann Co. Supply Crate Series #') ||
+                                    body.name.includes('Salvaged Mann Co. Supply Crate #')
+                                        ? name
+                                        : body.name
+                                } (${sku}).`
+                            );
                         }
                     });
                 }

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -177,6 +177,23 @@ export default class Pricelist extends EventEmitter {
                 continue;
             }
 
+            if (entry.name === null) {
+                // Check if entry.name is null, if true, get the name
+                if (entry.sku !== null) {
+                    // Check if entry.sku not null, if yes, then get name from it
+                    entry.name = this.schema.getName(SKU.fromString(entry.sku), false);
+
+                    if (entry.name === null) {
+                        // If entry.name still null after getting its name, then skip current iteration
+                        continue;
+                    }
+                } else {
+                    // Else if entry.sku is null, then skip current iteration
+                    continue;
+                }
+            }
+
+            // Bot can crash here if entry.name is null
             const name = entry.name.toLowerCase();
 
             if (search.includes('uncraftable')) {

--- a/src/classes/TF2GC.ts
+++ b/src/classes/TF2GC.ts
@@ -272,7 +272,7 @@ export = class TF2GC {
 
         this.listenForEvent(
             'itemRemoved',
-            function(item) {
+            item => {
                 return { success: item.id === job.assetid };
             },
             () => {
@@ -475,15 +475,15 @@ export = class TF2GC {
 
             this.listenForEvent(
                 'connectedToGC',
-                function() {
+                () => {
                     log.debug('running connectToGC iterator...');
                     return { success: true };
                 },
-                function() {
+                () => {
                     log.debug('onSuccess connectToGC.');
                     resolve();
                 },
-                function() {
+                () => {
                     log.debug('onFail connectToGC.');
                     bot.client.gamesPlayed([]);
                     reject(new Error('Could not connect to TF2 GC, restarting TF2..'));

--- a/src/classes/TF2Inventory.ts
+++ b/src/classes/TF2Inventory.ts
@@ -147,7 +147,7 @@ export = class TF2Inventory {
                         Cookie: 'user-id=' + uid(12)
                     }
                 },
-                function(err, response, body) {
+                (err, response, body) => {
                     if (err) {
                         return reject(err);
                     }

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -172,7 +172,7 @@ export = class Trades {
     getTradesWithPeople(steamIDs: SteamID[] | string[]): UnknownDictionary<number> {
         const tradesBySteamID = {};
 
-        steamIDs.forEach(function(steamID) {
+        steamIDs.forEach(steamID => {
             tradesBySteamID[steamID.toString()] = 0;
         });
 
@@ -687,7 +687,7 @@ export = class Trades {
                     operation.reset();
 
                     // Wait for bot to sign in to retry
-                    this.bot.getWebSession(true).asCallback(function() {
+                    this.bot.getWebSession(true).asCallback(() => {
                         // Callback was called, ignore error from callback and retry
                         operation.retry(err);
                     });

--- a/src/classes/UserCart.ts
+++ b/src/classes/UserCart.ts
@@ -58,7 +58,7 @@ class UserCart extends Cart {
             const requests = assetidsToCheck.map(assetid => {
                 return (callback: (err: Error | null, result: boolean | null) => void): void => {
                     log.debug('Dupe checking ' + assetid + '...');
-                    Promise.resolve(inventory.isDuped(assetid)).asCallback(function(err, result) {
+                    Promise.resolve(inventory.isDuped(assetid)).asCallback((err, result) => {
                         log.debug('Dupe check for ' + assetid + ' done');
                         callback(err, result);
                     });
@@ -66,7 +66,7 @@ class UserCart extends Cart {
             });
 
             try {
-                const result: (boolean | null)[] = await Promise.fromCallback(function(callback) {
+                const result: (boolean | null)[] = await Promise.fromCallback(callback => {
                     async.series(requests, callback);
                 });
 

--- a/src/lib/bans.ts
+++ b/src/lib/bans.ts
@@ -56,7 +56,7 @@ function isBptfSteamRepBanned(steamID: SteamID | string): Promise<boolean> {
                 }
 
                 const user = body.users[steamID64];
-                const isSteamRepBanned = user.bans ? user.bans.steamrep_scammer : false;
+                const isSteamRepBanned = user.bans ? user.bans.steamrep_scammer === 1 : false;
 
                 return resolve(isSteamRepBanned);
             }

--- a/src/lib/bans.ts
+++ b/src/lib/bans.ts
@@ -23,7 +23,7 @@ function isBptfBanned(steamID: SteamID | string): Promise<boolean> {
                 gzip: true,
                 json: true
             },
-            function(err, response, body) {
+            (err, response, body) => {
                 if (err) {
                     return reject(err);
                 }
@@ -50,7 +50,7 @@ function isBptfSteamRepBanned(steamID: SteamID | string): Promise<boolean> {
                 gzip: true,
                 json: true
             },
-            function(err, response, body) {
+            (err, response, body) => {
                 if (err) {
                     return reject(err);
                 }
@@ -77,7 +77,7 @@ function isSteamRepMarked(steamID: SteamID | string): Promise<boolean> {
                 gzip: true,
                 json: true
             },
-            function(err, response, body) {
+            (err, response, body) => {
                 if (err) {
                     return isBptfSteamRepBanned(steamID64);
                 }

--- a/src/lib/extend/item/getSKU.ts
+++ b/src/lib/extend/item/getSKU.ts
@@ -414,84 +414,84 @@ function getCrateSeries(item: EconItem): number | null {
         'Salvaged Mann Co. Supply Crate #50': 50
     };
 
-    const isOther = {
-        5048: 6, // Festive Winter Crate #6
-        5066: 22, // Refreshing Summer Cooler #22
-        5070: 35, // Naughty Winter Crate #35
-        5071: 36, // Nice Winter Crate #36
-        5078: 46, // Scorched Crate #46
-        5080: 48, // Fall Crate #48
-        5627: 51, // Eerie Crate #51
-        5629: 52, // Naughty Winter Crate 2012 #52
-        5630: 53, // Nice Winter Crate 2012 #53
-        5635: 58, // Robo Community Crate #58
-        5660: 60, // Select Reserve Mann Co. Supply Crate #60
-        5640: 61, // Summer Appetizer Crate #61
-        5642: 62, // Red Summer 2013 Cooler #62
-        5644: 63, // Orange Summer 2013 Cooler #63
-        5646: 64, // Yellow Summer 2013 Cooler #64
-        5648: 65, // Green Summer 2013 Cooler #65
-        5650: 66, // Aqua Summer 2013 Cooler #66
-        5652: 67, // Blue Summer 2013 Cooler #67
-        5654: 68, // Brown Summer 2013 Cooler #68
-        5656: 69, // Black Summer 2013 Cooler #69 // No #70
-        5708: 72, // Fall 2013 Acorns Crate #72
-        5709: 73, // Fall 2013 Gourd Crate #73
-        5712: 74, // Spooky Crate #74
-        5714: 78, // Naughty Winter Crate 2013 #78
-        5715: 79, // Nice Winter Crate 2013 #79 // No #80
-        5719: 81, // Mann Co. Strongbox #81
-        5734: 82, // Mann Co. Munition Crate #82
-        5735: 83, // Mann Co. Munition Crate #83
-        5742: 84, // Mann Co. Munition Crate #84
-        5752: 85, // Mann Co. Munition Crate #85
-        5761: 86, // Limited Late Summer Crate #86
-        5774: 87, // End of the Line Community Crate #87
-        5789: 88, // Naughty Winter Crate 2014 #88
-        5790: 89, // Nice Winter Crate 2014 #89
-        5781: 90, // Mann Co. Munition Crate #90
-        5802: 91, // Mann Co. Munition Crate #91
-        5803: 92, // Mann Co. Munition Crate #92
-        5806: 93, // The Concealed Killer Weapons Case #93
-        5807: 94, // The Powerhouse Weapons Case #94
-        5817: 95, // Gun Mettle Cosmetic Case #95
-        5822: 96, // Quarantined Collection Case #96
-        5823: 97, // Confidential Collection Case #97
-        5828: 98, // Gargoyle Case #98
-        5831: 99, // Pyroland Weapons Case #99
-        5832: 100, // Warbird Weapons Case #100
-        5842: 101, // Tough Break Cosmetic Case #101
-        5849: 102, // Mayflower Cosmetic Case #102
-        5859: 103, // Mann Co. Munition Crate #103
-        5861: 104, // Creepy Crawly Case #104
-        5865: 105, // Unlocked Winter 2016 Cosmetic Case #105
-        5867: 106, // Rainy Day Cosmetic Case #106
-        5871: 107, // Abominable Cosmetic Case #107
-        5875: 108, // Unleash the Beast Cosmetic Case #108
-        5883: 109, // Jungle Jackpot War Paint Case #109
-        5885: 110, // Infernal Reward War Paint Case #110
-        18000: 111, // 'Decorated War Hero' War Paint\nCivilian Grade Keyless Case
-        18001: 112, // 'Decorated War Hero' War Paint\nFreelance Grade Keyless Case
-        18002: 113, // 'Decorated War Hero' War Paint\nMercenary Grade Keyless Case
-        18003: 114, // 'Contract Campaigner' War Paint\nCivilian Grade Keyless Case
-        18004: 115, // 'Contract Campaigner' War Paint\nFreelance Grade Keyless Case
-        18005: 116, // 'Contract Campaigner' War Paint\nMercenary Grade Keyless Case
-        5888: 117, // Winter 2017 Cosmetic Case #117
-        5890: 118, // Winter 2017 War Paint Case #118
-        5893: 119, // Blue Moon Cosmetic Case #119
-        5894: 120, // Violet Vermin Case #120
-        5897: 121, // Scream Fortress X War Paint Case #121
-        5902: 122, // Winter 2018 Cosmetic Case #122
-        5904: 123, // Summer 2019 Cosmetic Case #123
-        5905: 124, // Spooky Spoils Case #124
-        5909: 125, // Winter 2019 Cosmetic Case #125
-        5912: 126, // Winter 2019 War Paint Case #126
-        5914: 127, // Summer 2020 Cosmetic Case #127
-        5915: 128, // Wicked Windfall Case #128
-        5918: 129 // Scream Fortress XII War Paint Case #129
-    };
+    // const isOther = {
+    //     5048: 6, // Festive Winter Crate #6
+    //     5066: 22, // Refreshing Summer Cooler #22
+    //     5070: 35, // Naughty Winter Crate #35
+    //     5071: 36, // Nice Winter Crate #36
+    //     5078: 46, // Scorched Crate #46
+    //     5080: 48, // Fall Crate #48
+    //     5627: 51, // Eerie Crate #51
+    //     5629: 52, // Naughty Winter Crate 2012 #52
+    //     5630: 53, // Nice Winter Crate 2012 #53
+    //     5635: 58, // Robo Community Crate #58
+    //     5660: 60, // Select Reserve Mann Co. Supply Crate #60
+    //     5640: 61, // Summer Appetizer Crate #61
+    //     5642: 62, // Red Summer 2013 Cooler #62
+    //     5644: 63, // Orange Summer 2013 Cooler #63
+    //     5646: 64, // Yellow Summer 2013 Cooler #64
+    //     5648: 65, // Green Summer 2013 Cooler #65
+    //     5650: 66, // Aqua Summer 2013 Cooler #66
+    //     5652: 67, // Blue Summer 2013 Cooler #67
+    //     5654: 68, // Brown Summer 2013 Cooler #68
+    //     5656: 69, // Black Summer 2013 Cooler #69 // No #70
+    //     5708: 72, // Fall 2013 Acorns Crate #72
+    //     5709: 73, // Fall 2013 Gourd Crate #73
+    //     5712: 74, // Spooky Crate #74
+    //     5714: 78, // Naughty Winter Crate 2013 #78
+    //     5715: 79, // Nice Winter Crate 2013 #79 // No #80
+    //     5719: 81, // Mann Co. Strongbox #81
+    //     5734: 82, // Mann Co. Munition Crate #82
+    //     5735: 83, // Mann Co. Munition Crate #83
+    //     5742: 84, // Mann Co. Munition Crate #84
+    //     5752: 85, // Mann Co. Munition Crate #85
+    //     5761: 86, // Limited Late Summer Crate #86
+    //     5774: 87, // End of the Line Community Crate #87
+    //     5789: 88, // Naughty Winter Crate 2014 #88
+    //     5790: 89, // Nice Winter Crate 2014 #89
+    //     5781: 90, // Mann Co. Munition Crate #90
+    //     5802: 91, // Mann Co. Munition Crate #91
+    //     5803: 92, // Mann Co. Munition Crate #92
+    //     5806: 93, // The Concealed Killer Weapons Case #93
+    //     5807: 94, // The Powerhouse Weapons Case #94
+    //     5817: 95, // Gun Mettle Cosmetic Case #95
+    //     5822: 96, // Quarantined Collection Case #96
+    //     5823: 97, // Confidential Collection Case #97
+    //     5828: 98, // Gargoyle Case #98
+    //     5831: 99, // Pyroland Weapons Case #99
+    //     5832: 100, // Warbird Weapons Case #100
+    //     5842: 101, // Tough Break Cosmetic Case #101
+    //     5849: 102, // Mayflower Cosmetic Case #102
+    //     5859: 103, // Mann Co. Munition Crate #103
+    //     5861: 104, // Creepy Crawly Case #104
+    //     5865: 105, // Unlocked Winter 2016 Cosmetic Case #105
+    //     5867: 106, // Rainy Day Cosmetic Case #106
+    //     5871: 107, // Abominable Cosmetic Case #107
+    //     5875: 108, // Unleash the Beast Cosmetic Case #108
+    //     5883: 109, // Jungle Jackpot War Paint Case #109
+    //     5885: 110, // Infernal Reward War Paint Case #110
+    //     18000: 111, // 'Decorated War Hero' War Paint\nCivilian Grade Keyless Case
+    //     18001: 112, // 'Decorated War Hero' War Paint\nFreelance Grade Keyless Case
+    //     18002: 113, // 'Decorated War Hero' War Paint\nMercenary Grade Keyless Case
+    //     18003: 114, // 'Contract Campaigner' War Paint\nCivilian Grade Keyless Case
+    //     18004: 115, // 'Contract Campaigner' War Paint\nFreelance Grade Keyless Case
+    //     18005: 116, // 'Contract Campaigner' War Paint\nMercenary Grade Keyless Case
+    //     5888: 117, // Winter 2017 Cosmetic Case #117
+    //     5890: 118, // Winter 2017 War Paint Case #118
+    //     5893: 119, // Blue Moon Cosmetic Case #119
+    //     5894: 120, // Violet Vermin Case #120
+    //     5897: 121, // Scream Fortress X War Paint Case #121
+    //     5902: 122, // Winter 2018 Cosmetic Case #122
+    //     5904: 123, // Summer 2019 Cosmetic Case #123
+    //     5905: 124, // Spooky Spoils Case #124
+    //     5909: 125, // Winter 2019 Cosmetic Case #125
+    //     5912: 126, // Winter 2019 War Paint Case #126
+    //     5914: 127, // Summer 2020 Cosmetic Case #127
+    //     5915: 128, // Wicked Windfall Case #128
+    //     5918: 129 // Scream Fortress XII War Paint Case #129
+    // };
 
-    let series = 0;
+    let series: number | null = null;
 
     if (defindex === 5022 && Object.keys(is5022).includes(item.market_hash_name)) {
         series = is5022[item.market_hash_name];
@@ -501,14 +501,16 @@ function getCrateSeries(item: EconItem): number | null {
         series = is5045[item.market_hash_name];
     } else if (defindex === 5068 && Object.keys(is5068).includes(item.market_hash_name)) {
         series = is5068[item.market_hash_name];
-    } else if (Object.keys(isOther).includes(defindex.toString())) {
-        series = isOther[defindex];
     }
+    // else if (Object.keys(isOther).includes(defindex.toString())) {
+    //     series = isOther[defindex];
+    // }
 
-    if (series !== 0) {
+    if (series !== null) {
         isCrate = true;
         return series;
     } else {
+        isCrate = false;
         return null;
     }
 }

--- a/src/lib/extend/item/getSKU.ts
+++ b/src/lib/extend/item/getSKU.ts
@@ -4,7 +4,11 @@ import SchemaManager from 'tf2-schema';
 import SKU from 'tf2-sku';
 import url from 'url';
 
+import log from '../../../lib/logger';
+
 import { fixItem } from '../../items';
+
+let isCrate = false;
 
 export = function(schema: SchemaManager.Schema): string {
     // @ts-ignore
@@ -25,8 +29,8 @@ export = function(schema: SchemaManager.Schema): string {
             effect: getEffect(self, schema),
             wear: getWear(self),
             paintkit: getPaintKit(self, schema),
-            quality2: getElevatedQuality(self)
-            // crateseries: getCrateSeries(self)
+            quality2: getElevatedQuality(self),
+            crateseries: getCrateSeries(self)
         },
         getOutput(self, schema)
     );
@@ -35,12 +39,16 @@ export = function(schema: SchemaManager.Schema): string {
         item.target = getTarget(self, schema);
     }
 
-    // Adds missing properties
-    item = fixItem(SKU.fromString(SKU.fromObject(item)), schema);
+    // Add missing properties, except if crates
+    if (!isCrate) {
+        item = fixItem(SKU.fromString(SKU.fromObject(item)), schema);
+    }
 
     if (item === null) {
         throw new Error('Unknown sku for item "' + self.market_hash_name + '"');
     }
+
+    log.debug(SKU.fromObject(item).toString());
 
     return SKU.fromObject(item);
 };
@@ -336,83 +344,171 @@ function getTarget(item: EconItem, schema: SchemaManager.Schema): number | null 
     return null;
 }
 
-// /**
-//  * Gets crate series of Mann Co. Supply Crate
-//  * @param item - Item object
-//  */
-// function getCrateSeries(item: EconItem): number | null {
-//     const defindex = getDefindex(item);
+/**
+ * Gets crate series of Mann Co. Supply Crate
+ * @param item - Item object
+ */
+function getCrateSeries(item: EconItem): number | null {
+    const defindex = getDefindex(item);
 
-//     const is5022 = {
-//         'Mann Co. Supply Crate Series #1': 1,
-//         'Mann Co. Supply Crate Series #3': 3,
-//         'Mann Co. Supply Crate Series #7': 7,
-//         'Mann Co. Supply Crate Series #12': 12,
-//         'Mann Co. Supply Crate Series #13': 13,
-//         'Mann Co. Supply Crate Series #18': 18,
-//         'Mann Co. Supply Crate Series #19': 19,
-//         'Mann Co. Supply Crate Series #23': 23,
-//         'Mann Co. Supply Crate Series #26': 26,
-//         'Mann Co. Supply Crate Series #31': 31,
-//         'Mann Co. Supply Crate Series #34': 34,
-//         'Mann Co. Supply Crate Series #39': 39,
-//         'Mann Co. Supply Crate Series #43': 43,
-//         'Mann Co. Supply Crate Series #47': 47,
-//         'Mann Co. Supply Crate Series #54': 54,
-//         'Mann Co. Supply Crate Series #57': 57,
-//         'Mann Co. Supply Crate Series #75': 75
-//     };
-//     const is5041 = {
-//         'Mann Co. Supply Crate Series #2': 2,
-//         'Mann Co. Supply Crate Series #4': 4,
-//         'Mann Co. Supply Crate Series #8': 8,
-//         'Mann Co. Supply Crate Series #11': 11,
-//         'Mann Co. Supply Crate Series #14': 14,
-//         'Mann Co. Supply Crate Series #17': 17,
-//         'Mann Co. Supply Crate Series #20': 20,
-//         'Mann Co. Supply Crate Series #24': 24,
-//         'Mann Co. Supply Crate Series #27': 27,
-//         'Mann Co. Supply Crate Series #32': 32,
-//         'Mann Co. Supply Crate Series #37': 37,
-//         'Mann Co. Supply Crate Series #42': 42,
-//         'Mann Co. Supply Crate Series #44': 44,
-//         'Mann Co. Supply Crate Series #49': 49,
-//         'Mann Co. Supply Crate Series #56': 56,
-//         'Mann Co. Supply Crate Series #71': 71,
-//         'Mann Co. Supply Crate Series #75': 76
-//     };
-//     const is5045 = {
-//         'Mann Co. Supply Crate Series #5': 5,
-//         'Mann Co. Supply Crate Series #9': 9,
-//         'Mann Co. Supply Crate Series #10': 10,
-//         'Mann Co. Supply Crate Series #15': 15,
-//         'Mann Co. Supply Crate Series #16': 16,
-//         'Mann Co. Supply Crate Series #21': 21,
-//         'Mann Co. Supply Crate #Series 25': 25,
-//         'Mann Co. Supply Crate #Series 28': 28,
-//         'Mann Co. Supply Crate Series #29': 29,
-//         'Mann Co. Supply Crate Series #33': 33,
-//         'Mann Co. Supply Crate Series #38': 38,
-//         'Mann Co. Supply Crate Series #41': 41,
-//         'Mann Co. Supply Crate Series #45': 45,
-//         'Mann Co. Supply Crate Series #55': 55,
-//         'Mann Co. Supply Crate Series #59': 59,
-//         'Mann Co. Supply Crate Series #77': 77
-//     };
+    const is5022 = {
+        'Mann Co. Supply Crate Series #1': 1,
+        'Mann Co. Supply Crate Series #3': 3,
+        'Mann Co. Supply Crate Series #7': 7,
+        'Mann Co. Supply Crate Series #12': 12,
+        'Mann Co. Supply Crate Series #13': 13,
+        'Mann Co. Supply Crate Series #18': 18,
+        'Mann Co. Supply Crate Series #19': 19,
+        'Mann Co. Supply Crate Series #23': 23,
+        'Mann Co. Supply Crate Series #26': 26,
+        'Mann Co. Supply Crate Series #31': 31,
+        'Mann Co. Supply Crate Series #34': 34,
+        'Mann Co. Supply Crate Series #39': 39,
+        'Mann Co. Supply Crate Series #43': 43,
+        'Mann Co. Supply Crate Series #47': 47,
+        'Mann Co. Supply Crate Series #54': 54,
+        'Mann Co. Supply Crate Series #57': 57,
+        'Mann Co. Supply Crate Series #75': 75
+    };
+    const is5041 = {
+        'Mann Co. Supply Crate Series #2': 2,
+        'Mann Co. Supply Crate Series #4': 4,
+        'Mann Co. Supply Crate Series #8': 8,
+        'Mann Co. Supply Crate Series #11': 11,
+        'Mann Co. Supply Crate Series #14': 14,
+        'Mann Co. Supply Crate Series #17': 17,
+        'Mann Co. Supply Crate Series #20': 20,
+        'Mann Co. Supply Crate Series #24': 24,
+        'Mann Co. Supply Crate Series #27': 27,
+        'Mann Co. Supply Crate Series #32': 32,
+        'Mann Co. Supply Crate Series #37': 37,
+        'Mann Co. Supply Crate Series #42': 42,
+        'Mann Co. Supply Crate Series #44': 44,
+        'Mann Co. Supply Crate Series #49': 49,
+        'Mann Co. Supply Crate Series #56': 56,
+        'Mann Co. Supply Crate Series #71': 71,
+        'Mann Co. Supply Crate Series #75': 76
+    };
+    const is5045 = {
+        'Mann Co. Supply Crate Series #5': 5,
+        'Mann Co. Supply Crate Series #9': 9,
+        'Mann Co. Supply Crate Series #10': 10,
+        'Mann Co. Supply Crate Series #15': 15,
+        'Mann Co. Supply Crate Series #16': 16,
+        'Mann Co. Supply Crate Series #21': 21,
+        'Mann Co. Supply Crate #Series 25': 25,
+        'Mann Co. Supply Crate #Series 28': 28,
+        'Mann Co. Supply Crate Series #29': 29,
+        'Mann Co. Supply Crate Series #33': 33,
+        'Mann Co. Supply Crate Series #38': 38,
+        'Mann Co. Supply Crate Series #41': 41,
+        'Mann Co. Supply Crate Series #45': 45,
+        'Mann Co. Supply Crate Series #55': 55,
+        'Mann Co. Supply Crate Series #59': 59,
+        'Mann Co. Supply Crate Series #77': 77
+    };
 
-//     let series = 0;
+    const is5068 = {
+        'Salvaged Mann Co. Supply Crate #30': 30,
+        'Salvaged Mann Co. Supply Crate #40': 40,
+        'Salvaged Mann Co. Supply Crate #50': 50
+    };
 
-//     if (defindex === 5022 && Object.keys(is5022).includes(item.name)) {
-//         series = is5022[item.name];
-//     } else if (defindex === 5041 && Object.keys(is5041).includes(item.name)) {
-//         series = is5041[item.name];
-//     } else if (defindex === 5045 && Object.keys(is5045).includes(item.name)) {
-//         series = is5045[item.name];
-//     }
+    const isOther = {
+        5048: 6, // Festive Winter Crate #6
+        5066: 22, // Refreshing Summer Cooler #22
+        5070: 35, // Naughty Winter Crate #35
+        5071: 36, // Nice Winter Crate #36
+        5078: 46, // Scorched Crate #46
+        5080: 48, // Fall Crate #48
+        5627: 51, // Eerie Crate #51
+        5629: 52, // Naughty Winter Crate 2012 #52
+        5630: 53, // Nice Winter Crate 2012 #53
+        5635: 58, // Robo Community Crate #58
+        5660: 60, // Select Reserve Mann Co. Supply Crate #60
+        5640: 61, // Summer Appetizer Crate #61
+        5642: 62, // Red Summer 2013 Cooler #62
+        5644: 63, // Orange Summer 2013 Cooler #63
+        5646: 64, // Yellow Summer 2013 Cooler #64
+        5648: 65, // Green Summer 2013 Cooler #65
+        5650: 66, // Aqua Summer 2013 Cooler #66
+        5652: 67, // Blue Summer 2013 Cooler #67
+        5654: 68, // Brown Summer 2013 Cooler #68
+        5656: 69, // Black Summer 2013 Cooler #69 // No #70
+        5708: 72, // Fall 2013 Acorns Crate #72
+        5709: 73, // Fall 2013 Gourd Crate #73
+        5712: 74, // Spooky Crate #74
+        5714: 78, // Naughty Winter Crate 2013 #78
+        5715: 79, // Nice Winter Crate 2013 #79 // No #80
+        5719: 81, // Mann Co. Strongbox #81
+        5734: 82, // Mann Co. Munition Crate #82
+        5735: 83, // Mann Co. Munition Crate #83
+        5742: 84, // Mann Co. Munition Crate #84
+        5752: 85, // Mann Co. Munition Crate #85
+        5761: 86, // Limited Late Summer Crate #86
+        5774: 87, // End of the Line Community Crate #87
+        5789: 88, // Naughty Winter Crate 2014 #88
+        5790: 89, // Nice Winter Crate 2014 #89
+        5781: 90, // Mann Co. Munition Crate #90
+        5802: 91, // Mann Co. Munition Crate #91
+        5803: 92, // Mann Co. Munition Crate #92
+        5806: 93, // The Concealed Killer Weapons Case #93
+        5807: 94, // The Powerhouse Weapons Case #94
+        5817: 95, // Gun Mettle Cosmetic Case #95
+        5822: 96, // Quarantined Collection Case #96
+        5823: 97, // Confidential Collection Case #97
+        5828: 98, // Gargoyle Case #98
+        5831: 99, // Pyroland Weapons Case #99
+        5832: 100, // Warbird Weapons Case #100
+        5842: 101, // Tough Break Cosmetic Case #101
+        5849: 102, // Mayflower Cosmetic Case #102
+        5859: 103, // Mann Co. Munition Crate #103
+        5861: 104, // Creepy Crawly Case #104
+        5865: 105, // Unlocked Winter 2016 Cosmetic Case #105
+        5867: 106, // Rainy Day Cosmetic Case #106
+        5871: 107, // Abominable Cosmetic Case #107
+        5875: 108, // Unleash the Beast Cosmetic Case #108
+        5883: 109, // Jungle Jackpot War Paint Case #109
+        5885: 110, // Infernal Reward War Paint Case #110
+        18000: 111, // 'Decorated War Hero' War Paint\nCivilian Grade Keyless Case
+        18001: 112, // 'Decorated War Hero' War Paint\nFreelance Grade Keyless Case
+        18002: 113, // 'Decorated War Hero' War Paint\nMercenary Grade Keyless Case
+        18003: 114, // 'Contract Campaigner' War Paint\nCivilian Grade Keyless Case
+        18004: 115, // 'Contract Campaigner' War Paint\nFreelance Grade Keyless Case
+        18005: 116, // 'Contract Campaigner' War Paint\nMercenary Grade Keyless Case
+        5888: 117, // Winter 2017 Cosmetic Case #117
+        5890: 118, // Winter 2017 War Paint Case #118
+        5893: 119, // Blue Moon Cosmetic Case #119
+        5894: 120, // Violet Vermin Case #120
+        5897: 121, // Scream Fortress X War Paint Case #121
+        5902: 122, // Winter 2018 Cosmetic Case #122
+        5904: 123, // Summer 2019 Cosmetic Case #123
+        5905: 124, // Spooky Spoils Case #124
+        5909: 125, // Winter 2019 Cosmetic Case #125
+        5912: 126, // Winter 2019 War Paint Case #126
+        5914: 127, // Summer 2020 Cosmetic Case #127
+        5915: 128, // Wicked Windfall Case #128
+        5918: 129 // Scream Fortress XII War Paint Case #129
+    };
 
-//     if (series !== 0) {
-//         return series;
-//     } else {
-//         return null;
-//     }
-// }
+    let series = 0;
+
+    if (defindex === 5022 && Object.keys(is5022).includes(item.market_hash_name)) {
+        series = is5022[item.market_hash_name];
+    } else if (defindex === 5041 && Object.keys(is5041).includes(item.market_hash_name)) {
+        series = is5041[item.market_hash_name];
+    } else if (defindex === 5045 && Object.keys(is5045).includes(item.market_hash_name)) {
+        series = is5045[item.market_hash_name];
+    } else if (defindex === 5068 && Object.keys(is5068).includes(item.market_hash_name)) {
+        series = is5068[item.market_hash_name];
+    } else if (Object.keys(isOther).includes(defindex.toString())) {
+        series = isOther[defindex];
+    }
+
+    if (series !== 0) {
+        isCrate = true;
+        return series;
+    } else {
+        return null;
+    }
+}

--- a/src/lib/extend/item/getSKU.ts
+++ b/src/lib/extend/item/getSKU.ts
@@ -4,7 +4,7 @@ import SchemaManager from 'tf2-schema';
 import SKU from 'tf2-sku';
 import url from 'url';
 
-import log from '../../../lib/logger';
+// import log from '../../../lib/logger';
 
 import { fixItem } from '../../items';
 
@@ -48,7 +48,7 @@ export = function(schema: SchemaManager.Schema): string {
         throw new Error('Unknown sku for item "' + self.market_hash_name + '"');
     }
 
-    log.debug(SKU.fromObject(item).toString());
+    // log.debug(SKU.fromObject(item).toString());
 
     return SKU.fromObject(item);
 };

--- a/src/lib/extend/item/hasDescription.ts
+++ b/src/lib/extend/item/hasDescription.ts
@@ -12,7 +12,7 @@ export = function(description: string): boolean {
         return false;
     }
 
-    return self.descriptions.some(function(d) {
+    return self.descriptions.some(d => {
         return d.value === description;
     });
 };

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -12,7 +12,7 @@ export function readFile(p: string, json: boolean): Promise<any> {
             return;
         }
 
-        fs.readFile(p, { encoding: 'utf8' }, function(err, data) {
+        fs.readFile(p, { encoding: 'utf8' }, (err, data) => {
             if (err) {
                 return reject(err);
             }
@@ -53,7 +53,7 @@ export function writeFile(p: string, data: any, json: boolean): Promise<void> {
         if (fs.existsSync(dir)) {
             writeFile();
         } else {
-            fs.mkdir(dir, { recursive: true }, function(err) {
+            fs.mkdir(dir, { recursive: true }, err => {
                 if (err) {
                     return reject(err);
                 }
@@ -64,7 +64,7 @@ export function writeFile(p: string, data: any, json: boolean): Promise<void> {
 
         function writeFile(): void {
             filesBeingSaved++;
-            fs.writeFile(p, write, { encoding: 'utf8' }, function(err) {
+            fs.writeFile(p, write, { encoding: 'utf8' }, err => {
                 filesBeingSaved--;
 
                 if (err) {
@@ -85,7 +85,7 @@ export function deleteFile(p: string): Promise<void> {
         }
 
         filesBeingSaved++;
-        fs.unlink(p, function(err) {
+        fs.unlink(p, err => {
             filesBeingSaved--;
             if (err) {
                 return reject(err);

--- a/src/lib/items.ts
+++ b/src/lib/items.ts
@@ -1,8 +1,6 @@
 import { Item } from '../types/TeamFortress2';
 import SchemaManager from 'tf2-schema';
 
-import isObject from 'isobject';
-
 export function fixItem(item: Item, schema: SchemaManager.Schema): Item {
     const schemaItem = schema.getItemByDefindex(item.defindex);
 
@@ -50,47 +48,47 @@ export function fixItem(item: Item, schema: SchemaManager.Schema): Item {
         }
     }
 
-    if (schemaItem.item_class === 'supply_crate') {
-        let series: number | null = null;
+    // if (schemaItem.item_class === 'supply_crate') {
+    //     let series: number | null = null;
 
-        if (schemaItem.attributes !== undefined) {
-            for (let i = 0; i < schemaItem.attributes.length; i++) {
-                const attribute = schemaItem.attributes[i];
+    //     if (schemaItem.attributes !== undefined) {
+    //         for (let i = 0; i < schemaItem.attributes.length; i++) {
+    //             const attribute = schemaItem.attributes[i];
 
-                if (
-                    attribute.name === 'set supply crate series'
-                    // !(attribute.value === 82 || attribute.value === 83 || attribute.value === 77)
-                ) {
-                    series = attribute.value;
-                }
-            }
-        }
+    //             if (
+    //                 attribute.name === 'set supply crate series'
+    //                 // !(attribute.value === 82 || attribute.value === 83 || attribute.value === 77)
+    //             ) {
+    //                 series = attribute.value;
+    //             }
+    //         }
+    //     }
 
-        if (series === null) {
-            const itemsGameItem = schema.raw.items_game.items[item.defindex];
+    //     if (series === null) {
+    //         const itemsGameItem = schema.raw.items_game.items[item.defindex];
 
-            if (
-                itemsGameItem.static_attrs !== undefined &&
-                itemsGameItem.static_attrs['set supply crate series'] !== undefined
-            ) {
-                // @ts-ignore
-                if (isObject(itemsGameItem.static_attrs['set supply crate series'])) {
-                    series = itemsGameItem.static_attrs['set supply crate series'].value;
-                } else {
-                    series = itemsGameItem.static_attrs['set supply crate series'];
-                }
-            }
-        }
+    //         if (
+    //             itemsGameItem.static_attrs !== undefined &&
+    //             itemsGameItem.static_attrs['set supply crate series'] !== undefined
+    //         ) {
+    //             // @ts-ignore
+    //             if (isObject(itemsGameItem.static_attrs['set supply crate series'])) {
+    //                 series = itemsGameItem.static_attrs['set supply crate series'].value;
+    //             } else {
+    //                 series = itemsGameItem.static_attrs['set supply crate series'];
+    //             }
+    //         }
+    //     }
 
-        if (series !== null) {
-            // @ts-ignore
-            // @TODO We are parsing a number from a number.
-            // If you meant to floor the int, use Math.floor()
-            // If you are expecting a string here,
-            // SchemaManager.attributes might be wrong.
-            item.crateseries = parseInt(series);
-        }
-    }
+    //     if (series !== null) {
+    //         // @ts-ignore
+    //         // @TODO We are parsing a number from a number.
+    //         // If you meant to floor the int, use Math.floor()
+    //         // If you are expecting a string here,
+    //         // SchemaManager.attributes might be wrong.
+    //         item.crateseries = parseInt(series);
+    //     }
+    // }
 
     if (item.effect !== null) {
         if (item.quality === 11) {

--- a/src/lib/items.ts
+++ b/src/lib/items.ts
@@ -1,6 +1,8 @@
 import { Item } from '../types/TeamFortress2';
 import SchemaManager from 'tf2-schema';
 
+import isObject from 'isobject';
+
 export function fixItem(item: Item, schema: SchemaManager.Schema): Item {
     const schemaItem = schema.getItemByDefindex(item.defindex);
 
@@ -48,47 +50,47 @@ export function fixItem(item: Item, schema: SchemaManager.Schema): Item {
         }
     }
 
-    // if (schemaItem.item_class === 'supply_crate') {
-    //     let series: number | null = null;
+    if (schemaItem.item_class === 'supply_crate') {
+        let series: number | null = null;
 
-    //     if (schemaItem.attributes !== undefined) {
-    //         for (let i = 0; i < schemaItem.attributes.length; i++) {
-    //             const attribute = schemaItem.attributes[i];
+        if (schemaItem.attributes !== undefined) {
+            for (let i = 0; i < schemaItem.attributes.length; i++) {
+                const attribute = schemaItem.attributes[i];
 
-    //             if (
-    //                 attribute.name === 'set supply crate series'
-    //                 // !(attribute.value === 82 || attribute.value === 83 || attribute.value === 77)
-    //             ) {
-    //                 series = attribute.value;
-    //             }
-    //         }
-    //     }
+                if (
+                    attribute.name === 'set supply crate series'
+                    // !(attribute.value === 82 || attribute.value === 83 || attribute.value === 77)
+                ) {
+                    series = attribute.value;
+                }
+            }
+        }
 
-    //     if (series === null) {
-    //         const itemsGameItem = schema.raw.items_game.items[item.defindex];
+        if (series === null) {
+            const itemsGameItem = schema.raw.items_game.items[item.defindex];
 
-    //         if (
-    //             itemsGameItem.static_attrs !== undefined &&
-    //             itemsGameItem.static_attrs['set supply crate series'] !== undefined
-    //         ) {
-    //             // @ts-ignore
-    //             if (isObject(itemsGameItem.static_attrs['set supply crate series'])) {
-    //                 series = itemsGameItem.static_attrs['set supply crate series'].value;
-    //             } else {
-    //                 series = itemsGameItem.static_attrs['set supply crate series'];
-    //             }
-    //         }
-    //     }
+            if (
+                itemsGameItem.static_attrs !== undefined &&
+                itemsGameItem.static_attrs['set supply crate series'] !== undefined
+            ) {
+                // @ts-ignore
+                if (isObject(itemsGameItem.static_attrs['set supply crate series'])) {
+                    series = itemsGameItem.static_attrs['set supply crate series'].value;
+                } else {
+                    series = itemsGameItem.static_attrs['set supply crate series'];
+                }
+            }
+        }
 
-    //     if (series !== null) {
-    //         // @ts-ignore
-    //         // @TODO We are parsing a number from a number.
-    //         // If you meant to floor the int, use Math.floor()
-    //         // If you are expecting a string here,
-    //         // SchemaManager.attributes might be wrong.
-    //         item.crateseries = parseInt(series);
-    //     }
-    // }
+        if (series !== null) {
+            // @ts-ignore
+            // @TODO We are parsing a number from a number.
+            // If you meant to floor the int, use Math.floor()
+            // If you are expecting a string here,
+            // SchemaManager.attributes might be wrong.
+            item.crateseries = parseInt(series);
+        }
+    }
 
     if (item.effect !== null) {
         if (item.quality === 11) {

--- a/src/lib/items.ts
+++ b/src/lib/items.ts
@@ -3,6 +3,8 @@ import SchemaManager from 'tf2-schema';
 
 import isObject from 'isobject';
 
+// import log from './logger';
+
 export function fixItem(item: Item, schema: SchemaManager.Schema): Item {
     const schemaItem = schema.getItemByDefindex(item.defindex);
 
@@ -105,29 +107,31 @@ export function fixItem(item: Item, schema: SchemaManager.Schema): Item {
         }
     }
 
-    if (item.paintkit !== null) {
-        const hasCorrectPaintkitAttribute =
-            schema.raw.items_game.items[item.defindex].static_attrs !== undefined &&
-            schema.raw.items_game.items[item.defindex].static_attrs['paintkit_proto_def_index'] == item.paintkit;
+    // This is broken
 
-        if (schemaItem.item_quality != 15 || !hasCorrectPaintkitAttribute) {
-            for (const defindex in schema.raw.items_game.items) {
-                if (!Object.prototype.hasOwnProperty.call(schema.raw.items_game.items, defindex)) {
-                    continue;
-                }
+    // if (item.paintkit !== null) {
+    //     const hasCorrectPaintkitAttribute =
+    //         schema.raw.items_game.items[item.defindex].static_attrs !== undefined &&
+    //         schema.raw.items_game.items[item.defindex].static_attrs['paintkit_proto_def_index'] == item.paintkit;
 
-                const itemsGameItem = schema.raw.items_game.items[defindex];
-                if (itemsGameItem.prefab === undefined || !itemsGameItem.prefab.startsWith('paintkit')) {
-                    continue;
-                }
+    //     if (schemaItem.item_quality != 15 || !hasCorrectPaintkitAttribute) {
+    //         for (const defindex in schema.raw.items_game.items) {
+    //             if (!Object.prototype.hasOwnProperty.call(schema.raw.items_game.items, defindex)) {
+    //                 continue;
+    //             }
 
-                if (itemsGameItem.static_attrs['paintkit_proto_def_index'] == item.paintkit) {
-                    item.defindex = parseInt(defindex);
-                    break;
-                }
-            }
-        }
-    }
+    //             const itemsGameItem = schema.raw.items_game.items[defindex];
+    //             if (itemsGameItem.prefab === undefined || !itemsGameItem.prefab.startsWith('paintkit')) {
+    //                 continue;
+    //             }
+
+    //             if (itemsGameItem.static_attrs['paintkit_proto_def_index'] == item.paintkit) {
+    //                 item.defindex = parseInt(defindex);
+    //                 break;
+    //             }
+    //         }
+    //     }
+    // }
 
     return item;
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -24,7 +24,7 @@ const colors = {
 
 winston.addColors(colors);
 
-const levelFilter = function(level: string): FormatWrap {
+const levelFilter = (level: string): FormatWrap => {
     return winston.format(info => {
         if (info.level !== level) {
             return false;
@@ -114,7 +114,7 @@ const transports = [
     }
 ];
 
-transports.forEach(function(transport) {
+transports.forEach(transport => {
     const type = transport.type;
 
     delete transport.type;

--- a/src/lib/ptf-api.ts
+++ b/src/lib/ptf-api.ts
@@ -45,8 +45,8 @@ function apiRequest(httpMethod: string, path: string, input: UnknownDictionary<a
 
     options[httpMethod === 'GET' ? 'qs' : 'body'] = input;
 
-    return new Promise(function(resolve, reject) {
-        request(options, function(err: Error | null, response: ResponseAsJSON, body: UnknownDictionary<any>) {
+    return new Promise((resolve, reject) => {
+        request(options, (err: Error | null, response: ResponseAsJSON, body: UnknownDictionary<any>) => {
             if (err) {
                 return reject(err);
             }


### PR DESCRIPTION
**Fix**
- fix the issue with the bot not able to properly detect/**sell** specific crate series (Mann Co. Supply Crate, Mann Co. Munition Crate, and Mann Co. Salvaged Crate) (cd1f4e2, 329883d) and Skins/War Paint (e82b089)


**Add**
- add bot crash preventive measure
	- bot crash when Steam went down and fail to obtain bot SteamID (3436f96)
	- bot crash when prices entry output as null because of an unknown cause when using searchByName() function (`!price`, `!buy`, `!sell`, `!buycart` and `!sellcart` commands affected) (35ad62e)
- add the bot to always send alert to admins (Steam Chat or Discord Webhook under `SOMETHING_WRONG_ALERT`) when the bot bought high valued items that will be automatically disabled (was added on [v1.5.4](https://github.com/idinium96/tf2autobot/releases/tag/v1.5.4) update). (566fb59)
- Discord Webhook: auto-fill `DISCORD_WEBHOOK_USERNAME` and `DISCORD_WEBHOOK_AVATAR_URL` with bot Steam name and avatar if empty. (168e1ec, 36261dc)

**Changes**
- items that are in the pricelist and have `enabled=false` will not be priced when `DISABLE_GIVE_PRICE_TO_INVALID_ITEMS` is set to `true` and will be skipped for review under `INVALID_ITEMS`. (6f2b6b9)
- revert changes with `CUSTOM_SUCCESS_MESSAGE` from [v1.6.0](https://github.com/idinium96/tf2autobot/releases/tag/v1.6.0) update. (39a5d16)
- update messages to be more grammatically correct. (ec857ff)
- if `AUTOBUMP` is set to `true` and account is not premium on Backpack.tf, disable auto-check for missing sell orders (added on [v1.6.0](https://github.com/idinium96/tf2autobot/releases/tag/v1.6.0)  update). (d1c380f)
- get backpack slots from backpack.tf API instead of Steam. (f2e9837)
- remove `fromEnv` and change most 'function' to `=>` (arrow function). (0bde5f3)