### PR TITLE
v1.6.6

### DIFF
--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -209,7 +209,7 @@ export = class MyHandler extends Handler {
     getBotInfo(): { name: string; avatarURL: string; steamID: string } {
         const name = this.botName;
         const avatarURL = this.botAvatarURL;
-        const steamID = this.botSteamID.toString();
+        const steamID = this.botSteamID.getSteamID64();
         return { name, avatarURL, steamID };
     }
 


### PR DESCRIPTION
- using `toString()` on SteamID would likely to cause the bot to crash. Use `getSteamID64()` instead. (5f3f62b)