### PR TITLE
Message typo correction

### DIFF
--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -2523,14 +2523,14 @@ export = class Commands {
                     if (isManyItems) {
                         this.bot.sendMessage(
                             offer.partner,
-                            'My owner have manually accepted your offer and the trade will take a while to complete since it is quite a big offer.' +
-                                ' If the trade did not complete after 5-10 minutes had passed, please send your offer again or add me and use !sell/!sellcart or !buy/!buycart command.'
+                            'My owner has manually accepted your offer. The trade may take a while to finalize due to it being a large offer.' +
+                                ' If the trade does not finalize after 5-10 minutes has passed, please send your offer again, or add me and use the !sell/!sellcart or !buy/!buycart command.'
                         );
                     } else {
                         this.bot.sendMessage(
                             offer.partner,
-                            'My owner have manually accepted your offer and the trade will be completed in seconds.' +
-                                ' If the trade did not complete after 1-2 minutes had passed, please send your offer again or add me and use !sell/!sellcart or !buy/!buycart command.'
+                            'I have accepted your offer. The trade should be finalized shortly.' +
+                                ' If the trade does not finalize after 1-2 minutes has passed, please send your offer again, or add me and use the !sell/!sellcart or !buy/!buycart command.'
                         );
                     }
                     // Send message to recipient if includes some messages
@@ -2553,13 +2553,13 @@ export = class Commands {
 
                     this.bot.sendMessage(
                         steamID,
-                        `❌ Offer #${offer.id} has been automatically decline: contain${
+                        `❌ Offer #${offer.id} has been automatically declined: contain${
                             hasNot5Uses && hasNot25Uses
                                 ? 'Dueling Mini-Game and/or Noise Maker'
                                 : hasNot5Uses
                                 ? 'Dueling Mini-Game'
                                 : 'Noise Maker'
-                        } that are not full after re-check...`
+                        } that is not full after re-check...`
                     );
 
                     this.bot.sendMessage(

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -2553,13 +2553,13 @@ export = class Commands {
 
                     this.bot.sendMessage(
                         steamID,
-                        `❌ Offer #${offer.id} has been automatically declined: contain${
+                        `❌ Offer #${offer.id} has been automatically declined: contains ${
                             hasNot5Uses && hasNot25Uses
                                 ? 'Dueling Mini-Game and/or Noise Maker'
                                 : hasNot5Uses
                                 ? 'Dueling Mini-Game'
                                 : 'Noise Maker'
-                        } that are not full after re-check...`
+                        } that is not full after re-check...`
                     );
 
                     this.bot.sendMessage(

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -2529,7 +2529,7 @@ export = class Commands {
                     } else {
                         this.bot.sendMessage(
                             offer.partner,
-                            'I have accepted your offer. The trade should be finalized shortly.' +
+                            'My owner has manually accepted your offer. The trade should be finalized shortly.' +
                                 ' If the trade does not finalize after 1-2 minutes has passed, please send your offer again, or add me and use the !sell/!sellcart or !buy/!buycart command.'
                         );
                     }
@@ -2559,7 +2559,7 @@ export = class Commands {
                                 : hasNot5Uses
                                 ? 'Dueling Mini-Game'
                                 : 'Noise Maker'
-                        } that is not full after re-check...`
+                        } that are not full after re-check...`
                     );
 
                     this.bot.sendMessage(

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1491,13 +1491,13 @@ export = class MyHandler extends Handler {
                     this.bot.sendMessage(
                         offer.partner,
                         'I have accepted your offer. The trade may take a while to finalize due to it being a large offer.' +
-                            ' If the trade does not finalize after 5-10 minutes had passed, please send your offer again, or add me and use the !sell/!sellcart or !buy/!buycart command.'
+                            ' If the trade does not finalize after 5-10 minutes has passed, please send your offer again, or add me and use the !sell/!sellcart or !buy/!buycart command.'
                     );
                 } else {
                     this.bot.sendMessage(
                         offer.partner,
                         'I have accepted your offer. The trade should be finalized shortly.' +
-                            ' If the trade does not finalize after 1-2 minutes had passed, please send your offer again, or add me and use the !sell/!sellcart or !buy/!buycart command.'
+                            ' If the trade does not finalize after 1-2 minutes has passed, please send your offer again, or add me and use the !sell/!sellcart or !buy/!buycart command.'
                     );
                 }
 
@@ -1572,13 +1572,13 @@ export = class MyHandler extends Handler {
             this.bot.sendMessage(
                 offer.partner,
                 'I have accepted your offer. The trade may take a while to finalize due to it being a large offer.' +
-                    ' If the trade does not finalize after 5-10 minutes had passed, please send your offer again, or add me and use the !sell/!sellcart or !buy/!buycart command.'
+                    ' If the trade does not finalize after 5-10 minutes has passed, please send your offer again, or add me and use the !sell/!sellcart or !buy/!buycart command.'
             );
         } else {
             this.bot.sendMessage(
                 offer.partner,
                 'I have accepted your offer. The trade will be finalized shortly.' +
-                    ' If the trade does not finalize after 1-2 minutes had passed, please send your offer again, or add me and use the !sell/!sellcart or !buy/!buycart command.'
+                    ' If the trade does not finalize after 1-2 minutes has passed, please send your offer again, or add me and use the !sell/!sellcart or !buy/!buycart command.'
             );
         }
 
@@ -1730,7 +1730,7 @@ export = class MyHandler extends Handler {
                         reason = 'Failed to accept mobile confirmation';
                     } else {
                         reason =
-                            "The offer has been active for a while. If the offer was just created, this is likely an issue on Steam's end. Please try again later.";
+                            "The offer has been active for a while. If the offer was just created, this is likely an issue on Steam's end. Please try again.";
                     }
 
                     this.bot.sendMessage(

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1577,7 +1577,7 @@ export = class MyHandler extends Handler {
         } else {
             this.bot.sendMessage(
                 offer.partner,
-                'I have accepted your offer. The trade will be finalized in shortly.' +
+                'I have accepted your offer. The trade will be finalized shortly.' +
                     ' If the trade does not finalize after 1-2 minutes had passed, please send your offer again, or add me and use the !sell/!sellcart or !buy/!buycart command.'
             );
         }


### PR DESCRIPTION
This commit fixes a typo in the "Trade should be finalized shortly" message, as well as updates other messages sent to users. This change is very small, and most likely does not warrant its own version change