### PR TITLE
MyHandler: Uptime logic cleanup

### DIFF
--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -2034,12 +2034,12 @@ export = class MyHandler extends Handler {
             const daysDiff = currentTime.diff(uptimeAsMoment, 'days');
 
             // If the bot has been up for ~1 day, show the exact amount of hours
+            // If the bot has been up for ~1 month, show the exact amount of days
+            // Otherwise, show the uptime as it is
             if (hoursDiff >= 21.5 && hoursDiff < 35.5) {
                 log.debug(`Bot has been up for ${hoursDiff} hours.`);
-                // If the bot has been up for ~1 month, show the exact amount of days
             } else if (daysDiff >= 25.5) {
                 log.debug(`Bot has been up for ${daysDiff} days.`);
-                // Otherwise, show the difference as it is
             } else {
                 log.debug(`Bot has been up for ${uptimeAsMoment.from(currentTime, true)}.`);
             }

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -2037,9 +2037,9 @@ export = class MyHandler extends Handler {
             // If the bot has been up for ~1 month, show the exact amount of days
             // Otherwise, show the uptime as it is
             if (hoursDiff >= 21.5 && hoursDiff < 35.5) {
-                log.debug(`Bot has been up for ${hoursDiff} hours.`);
+                log.debug(`Bot has been up for a day (${hoursDiff} hours).`);
             } else if (daysDiff >= 25.5) {
-                log.debug(`Bot has been up for ${daysDiff} days.`);
+                log.debug(`Bot has been up for a month (${daysDiff} days).`);
             } else {
                 log.debug(`Bot has been up for ${uptimeAsMoment.from(currentTime, true)}.`);
             }

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -2028,17 +2028,21 @@ export = class MyHandler extends Handler {
             this.sortInventory();
 
             // Tell bot uptime
-            const now = moment().valueOf();
-            const diffTime = now - this.uptime;
+            const currentTime = moment();
+            const uptimeAsMoment = moment.unix(this.uptime);
+            const hoursDiff = currentTime.diff(uptimeAsMoment, 'hours');
+            const daysDiff = currentTime.diff(uptimeAsMoment, 'days');
 
-            const printTime =
-                diffTime >= 21.5 * 60 * 60 * 1000 && diffTime < 35.5 * 60 * 60 * 1000 // 21.5 h - 35.5 hours will show "a day", so show hours in bracket.
-                    ? ' (' + Math.round(diffTime / (1 * 60 * 60 * 1000)) + ' hours)'
-                    : diffTime >= 25.5 * 24 * 60 * 60 * 1000 // More than 25.5 days, will become "a month", so show how many days in bracket.
-                    ? ' (' + Math.round(diffTime / (1 * 24 * 60 * 60 * 1000)) + ' days)'
-                    : '';
-
-            log.debug(`Bot has been up for ${moment(this.uptime).fromNow(true) + printTime}.`);
+            // If the bot has been up for ~1 day, show the exact amount of hours
+            if (hoursDiff >= 21.5 && hoursDiff < 35.5) {
+                log.debug(`Bot has been up for ${hoursDiff} hours.`);
+                // If the bot has been up for ~1 month, show the exact amount of days
+            } else if (daysDiff >= 25.5) {
+                log.debug(`Bot has been up for ${daysDiff} days.`);
+                // Otherwise, show the difference as it is
+            } else {
+                log.debug(`Bot has been up for ${uptimeAsMoment.from(currentTime, true)}.`);
+            }
 
             // Update listings
             const diff = offer.getDiff() || {};


### PR DESCRIPTION
These code changes clean up the current `!uptime` logic.

Below are some example outputs from these code changes:
**Bot has been up for ~10 seconds:** `"Bot has been up for a few seconds."`
**Bot has been up for 3 minutes:** `"Bot has been up for 3 minutes."`
**Bot has been up for exactly 24 hours:** `"Bot has been up for a day (24 hours)."`
**Bot has been up for exactly 30 hours:** `"Bot has been up for a day (30 hours)."`
**Bot has been up for exactly 48 hours:** `"Bot has been up for 2 days."`
**Bot has been up for 2 weeks:** `"Bot has been up for 14 days."`
**Bot has been up for 4 weeks:** `"Bot has been up for a month (28 days)."`