### PR TITLE
Autokeys - Scrap Adjustment investigation and solution

### DIFF
--- a/src/classes/Autokeys.ts
+++ b/src/classes/Autokeys.ts
@@ -1,5 +1,5 @@
 import Bot from './Bot';
-import { EntryData } from './Pricelist';
+import { EntryData, PricelistChangedSource } from './Pricelist';
 // import moment from 'moment-timezone';
 
 import Currencies from 'tf2-currencies';
@@ -713,7 +713,7 @@ export = class Autokeys {
             } as any;
         }
         this.bot.pricelist
-            .addPrice(entry as EntryData, false)
+            .addPrice(entry as EntryData, false, PricelistChangedSource.Autokeys)
             .then(data => {
                 log.debug(`✅ Automatically added Mann Co. Supply Crate Key to buy.`);
                 this.bot.listings.checkBySKU(data.sku, data);
@@ -784,7 +784,7 @@ export = class Autokeys {
             } as any;
         }
         this.bot.pricelist
-            .addPrice(entry as EntryData, false)
+            .addPrice(entry as EntryData, false, PricelistChangedSource.Autokeys)
             .then(data => {
                 log.debug(`✅ Automatically added Mann Co. Supply Crate Key to sell.`);
                 this.bot.listings.checkBySKU(data.sku, data);
@@ -834,7 +834,7 @@ export = class Autokeys {
             } as any;
         }
         this.bot.pricelist
-            .addPrice(entry as EntryData, false)
+            .addPrice(entry as EntryData, false, PricelistChangedSource.Autokeys)
             .then(data => {
                 log.debug(`✅ Automatically added Mann Co. Supply Crate Key to bank.`);
                 this.bot.listings.checkBySKU(data.sku, data);
@@ -905,7 +905,7 @@ export = class Autokeys {
             } as any;
         }
         this.bot.pricelist
-            .updatePrice(entry as EntryData, false)
+            .updatePrice(entry as EntryData, false, PricelistChangedSource.Autokeys)
             .then(data => {
                 log.debug(`✅ Automatically update Mann Co. Supply Crate Key to buy.`);
                 this.bot.listings.checkBySKU(data.sku, data);
@@ -976,7 +976,7 @@ export = class Autokeys {
             } as any;
         }
         this.bot.pricelist
-            .updatePrice(entry as EntryData, false)
+            .updatePrice(entry as EntryData, false, PricelistChangedSource.Autokeys)
             .then(data => {
                 log.debug(`✅ Automatically updated Mann Co. Supply Crate Key to sell.`);
                 this.bot.listings.checkBySKU(data.sku, data);
@@ -1026,7 +1026,7 @@ export = class Autokeys {
             } as any;
         }
         this.bot.pricelist
-            .updatePrice(entry as EntryData, false)
+            .updatePrice(entry as EntryData, false, PricelistChangedSource.Autokeys)
             .then(data => {
                 log.debug(`✅ Automatically updated Mann Co. Supply Crate Key to bank.`);
                 this.bot.listings.checkBySKU(data.sku, data);
@@ -1076,7 +1076,7 @@ export = class Autokeys {
             } as any;
         }
         this.bot.pricelist
-            .updatePrice(entry as EntryData, false)
+            .updatePrice(entry as EntryData, false, PricelistChangedSource.Autokeys)
             .then(data => {
                 log.debug(`✅ Automatically disabled Autokeys.`);
                 this.bot.listings.checkBySKU(data.sku, data);

--- a/src/classes/Autokeys.ts
+++ b/src/classes/Autokeys.ts
@@ -106,6 +106,7 @@ export = class Autokeys {
         const currRef = pure.refTotalInScrap;
 
         const keyEntry = this.bot.pricelist.getPrice('5021;6', false);
+        // let us see what you start from here...
 
         const currKeyPrice = this.bot.pricelist.getKeyPrices();
 

--- a/src/classes/Autokeys.ts
+++ b/src/classes/Autokeys.ts
@@ -697,7 +697,7 @@ export = class Autokeys {
                 autoprice: false,
                 sell: {
                     keys: 0,
-                    metal: Currencies.toRefined(keyPrices.sell.toValue() - this.scrapAdjustmentValue)
+                    metal: Currencies.toRefined(keyPrices.sell.toValue() + this.scrapAdjustmentValue)
                 },
                 buy: {
                     keys: 0,
@@ -772,7 +772,7 @@ export = class Autokeys {
                 },
                 buy: {
                     keys: 0,
-                    metal: Currencies.toRefined(keyPrices.buy.toValue() + this.scrapAdjustmentValue)
+                    metal: Currencies.toRefined(keyPrices.buy.toValue() - this.scrapAdjustmentValue)
                 },
                 min: minKeys,
                 max: maxKeys,
@@ -889,7 +889,7 @@ export = class Autokeys {
                 autoprice: false,
                 sell: {
                     keys: 0,
-                    metal: Currencies.toRefined(keyPrices.sell.toValue() - this.scrapAdjustmentValue)
+                    metal: Currencies.toRefined(keyPrices.sell.toValue() + this.scrapAdjustmentValue)
                 },
                 buy: {
                     keys: 0,
@@ -964,7 +964,7 @@ export = class Autokeys {
                 },
                 buy: {
                     keys: 0,
-                    metal: Currencies.toRefined(keyPrices.buy.toValue() + this.scrapAdjustmentValue)
+                    metal: Currencies.toRefined(keyPrices.buy.toValue() - this.scrapAdjustmentValue)
                 },
                 min: minKeys,
                 max: maxKeys,

--- a/src/classes/Autokeys.ts
+++ b/src/classes/Autokeys.ts
@@ -697,7 +697,7 @@ export = class Autokeys {
                 autoprice: false,
                 sell: {
                     keys: 0,
-                    metal: Currencies.toRefined(keyPrices.sell.toValue() + this.scrapAdjustmentValue)
+                    metal: Currencies.toRefined(keyPrices.sell.toValue() - this.scrapAdjustmentValue)
                 },
                 buy: {
                     keys: 0,
@@ -768,7 +768,7 @@ export = class Autokeys {
                 autoprice: false,
                 sell: {
                     keys: 0,
-                    metal: Currencies.toRefined(keyPrices.sell.toValue() + this.scrapAdjustmentValue)
+                    metal: Currencies.toRefined(keyPrices.sell.toValue() - this.scrapAdjustmentValue)
                 },
                 buy: {
                     keys: 0,
@@ -889,7 +889,7 @@ export = class Autokeys {
                 autoprice: false,
                 sell: {
                     keys: 0,
-                    metal: Currencies.toRefined(keyPrices.sell.toValue() + this.scrapAdjustmentValue)
+                    metal: Currencies.toRefined(keyPrices.sell.toValue() - this.scrapAdjustmentValue)
                 },
                 buy: {
                     keys: 0,
@@ -960,7 +960,7 @@ export = class Autokeys {
                 autoprice: false,
                 sell: {
                     keys: 0,
-                    metal: Currencies.toRefined(keyPrices.sell.toValue() + this.scrapAdjustmentValue)
+                    metal: Currencies.toRefined(keyPrices.sell.toValue() - this.scrapAdjustmentValue)
                 },
                 buy: {
                     keys: 0,

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -8,7 +8,7 @@ import TradeOfferManager from 'steam-tradeoffer-manager';
 
 import Bot from './Bot';
 import CommandParser from './CommandParser';
-import { Entry, EntryData } from './Pricelist';
+import { Entry, EntryData, PricelistChangedSource } from './Pricelist';
 import Cart from './Cart';
 import AdminCart from './AdminCart';
 import UserCart from './UserCart';
@@ -1295,7 +1295,7 @@ export = class Commands {
         }
 
         this.bot.pricelist
-            .addPrice(params as EntryData, true)
+            .addPrice(params as EntryData, true, PricelistChangedSource.Command)
             .then(entry => {
                 this.bot.sendMessage(steamID, `✅ Added "${entry.name}".`);
             })
@@ -1653,7 +1653,7 @@ export = class Commands {
         }
 
         this.bot.pricelist
-            .updatePrice(entryData, true)
+            .updatePrice(entryData, true, PricelistChangedSource.Command)
             .then(entry => {
                 this.bot.sendMessage(steamID, `✅ Updated "${entry.name}".`);
             })


### PR DESCRIPTION
Since v1.7.0 update, if `ENABLE_AUTOKEYS` and `DISABLE_SCRAP_ADJUSTMENT` are set to `true`, the key rate will add `SCRAP_ADJUSTMENT_VALUE` value on every trade made.