### PR TITLE
v1.7.2

### DIFF
--- a/src/classes/Autokeys.ts
+++ b/src/classes/Autokeys.ts
@@ -1037,7 +1037,6 @@ export = class Autokeys {
 
     disable(onShutdown = false): void {
         const keyPrices = this.bot.pricelist.getKeyPrices();
-        log.debug('on Autokeys Disabling key prices', keyPrices);
         let entry;
         if (keyPrices.src !== 'manual') {
             entry = {
@@ -1077,7 +1076,7 @@ export = class Autokeys {
         this.bot.pricelist
             .updatePrice(entry as EntryData, false, PricelistChangedSource.Autokeys)
             .then(data => {
-                log.debug('✅ Automatically disabled Autokeys.', data);
+                log.debug('✅ Automatically disabled Autokeys.');
                 if (!onShutdown) {
                     this.bot.listings.checkBySKU(data.sku, data);
                 }

--- a/src/classes/Autokeys.ts
+++ b/src/classes/Autokeys.ts
@@ -1035,8 +1035,9 @@ export = class Autokeys {
             });
     }
 
-    disable(): void {
+    disable(onShutdown = false): void {
         const keyPrices = this.bot.pricelist.getKeyPrices();
+        log.debug('on Autokeys Disabling key prices', keyPrices);
         let entry;
         if (keyPrices.src !== 'manual') {
             entry = {
@@ -1076,8 +1077,10 @@ export = class Autokeys {
         this.bot.pricelist
             .updatePrice(entry as EntryData, false, PricelistChangedSource.Autokeys)
             .then(data => {
-                log.debug(`✅ Automatically disabled Autokeys.`);
-                this.bot.listings.checkBySKU(data.sku, data);
+                log.debug('✅ Automatically disabled Autokeys.', data);
+                if (!onShutdown) {
+                    this.bot.listings.checkBySKU(data.sku, data);
+                }
             })
             .catch(err => {
                 log.warn(`❌ Failed to disable Autokeys: ${err.message}`);

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -817,23 +817,14 @@ export = class Commands {
                 process.env.DISABLE_DISCORD_WEBHOOK_MESSAGE_FROM_PARTNER === 'false' &&
                 process.env.DISCORD_WEBHOOK_MESSAGE_FROM_PARTNER_URL
             ) {
-                this.discord.sendPartnerMessage(
-                    steamID.toString(),
-                    msg,
-                    adminDetails.player_name,
-                    adminDetails.avatar_url_full,
-                    links.steamProfile,
-                    links.backpackTF,
-                    links.steamREP,
-                    time.time
-                );
+                this.discord.sendPartnerMessage(steamID.toString(), msg, adminDetails, links, time.time);
             } else {
                 this.bot.messageAdmins(
                     `/quote 💬 You've got a message from #${steamID} (${adminDetails.player_name}):` +
                         `"${msg}". ` +
-                        `\nSteam: ${links.steamProfile}` +
-                        `\nBackpack.tf: ${links.backpackTF}` +
-                        `\nSteamREP: ${links.steamREP}`,
+                        `\nSteam: ${links.steam}` +
+                        `\nBackpack.tf: ${links.bptf}` +
+                        `\nSteamREP: ${links.steamrep}`,
                     []
                 );
             }
@@ -2727,7 +2718,7 @@ export = class Commands {
 
         const links = (this.bot.handler as MyHandler).tradePartnerLinks(offerData.partner.toString());
         reply +=
-            `\n\nSteam: ${links.steamProfile}\nBackpack.tf: ${links.backpackTF}\nSteamREP: ${links.steamREP}` +
+            `\n\nSteam: ${links.steam}\nBackpack.tf: ${links.bptf}\nSteamREP: ${links.steamrep}` +
             `\n\n⚠️ Send "!accept ${offerId}" to accept or "!decline ${offerId}" to decline this offer.`;
 
         this.bot.sendMessage(steamID, reply);

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -132,7 +132,7 @@ export = class Commands {
     }
 
     processMessage(steamID: SteamID, message: string): void {
-        const command = CommandParser.getCommand(message);
+        const command = CommandParser.getCommand(message.toLowerCase());
 
         const isAdmin = this.bot.isAdmin(steamID);
 

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -1749,7 +1749,6 @@ export = class Commands {
                 newPricelistCount = pricelist.filter(entry =>
                     entry.group ? [params.withgroup.toLowerCase()].includes(entry.group.toLowerCase()) : false
                 );
-                log.debug('newPricelistCount: ', newPricelistCount.length);
 
                 if (newPricelistCount.length === 0) {
                     this.bot.sendMessage(
@@ -1763,7 +1762,6 @@ export = class Commands {
                 newPricelist = pricelist.filter(entry =>
                     entry.group ? ![params.withgroup.toLowerCase()].includes(entry.group.toLowerCase()) : true
                 );
-                log.debug('newPricelist: ', newPricelist.length);
             } else {
                 newPricelistCount = pricelist;
             }

--- a/src/classes/DiscordWebhook.ts
+++ b/src/classes/DiscordWebhook.ts
@@ -121,11 +121,8 @@ export = class DiscordWebhookClass {
     sendPartnerMessage(
         steamID: string,
         msg: string,
-        theirName: string,
-        theirAvatar: string,
-        steamProfile: string,
-        backpackTF: string,
-        steamREP: string,
+        their: { player_name: string; avatar_url_full: string },
+        links: { steam: string; bptf: string; steamrep: string },
         time: string
     ): void {
         const botInfo = (this.bot.handler as MyHandler).getBotInfo();
@@ -140,15 +137,15 @@ export = class DiscordWebhookClass {
             embeds: [
                 {
                     author: {
-                        name: theirName,
-                        url: steamProfile,
-                        icon_url: theirAvatar
+                        name: their.player_name,
+                        url: links.steam,
+                        icon_url: their.avatar_url_full
                     },
                     footer: {
                         text: `Partner SteamID: ${steamID} • ${time}`
                     },
                     title: '',
-                    description: `💬 ${msg}\n\n${quickLinks(theirName, { steamProfile, backpackTF, steamREP })}`,
+                    description: `💬 ${msg}\n\n${quickLinks(their.player_name, links)}`,
                     color: process.env.DISCORD_WEBHOOK_EMBED_COLOR_IN_DECIMAL_INDEX
                 }
             ]
@@ -167,7 +164,7 @@ export = class DiscordWebhookClass {
         time: string,
         keyPrices: { buy: Currencies; sell: Currencies; src: string },
         value: { diff: number; diffRef: number; diffKey: string },
-        links: { steamProfile: string; backpackTF: string; steamREP: string },
+        links: { steam: string; bptf: string; steamrep: string },
         items: {
             invalid: string[];
             overstock: string[];
@@ -246,7 +243,7 @@ export = class DiscordWebhookClass {
                     {
                         author: {
                             name: 'Offer from: ' + partnerName,
-                            url: links.steamProfile,
+                            url: links.steam,
                             icon_url: partnerAvatar
                         },
                         footer: {
@@ -330,7 +327,7 @@ export = class DiscordWebhookClass {
         keyPrices: { buy: Currencies; sell: Currencies; src: string },
         value: { diff: number; diffRef: number; diffKey: string },
         items: { their: string[]; our: string[] },
-        links: { steamProfile: string; backpackTF: string; steamREP: string },
+        links: { steam: string; bptf: string; steamrep: string },
         time: string
     ): void {
         const ourItems = items.our;
@@ -426,7 +423,7 @@ export = class DiscordWebhookClass {
                     {
                         author: {
                             name: `Trade from: ${personaName} #${tradesMade.toString()}`,
-                            url: links.steamProfile,
+                            url: links.steam,
                             icon_url: avatarFull
                         },
                         footer: {
@@ -615,8 +612,8 @@ function listItems(items: {
     return list;
 }
 
-function quickLinks(name: string, links: { steamProfile: string; backpackTF: string; steamREP: string }): string {
-    return `🔍 ${name}'s info:\n[Steam Profile](${links.steamProfile}) | [backpack.tf](${links.backpackTF}) | [steamREP](${links.steamREP})`;
+function quickLinks(name: string, links: { steam: string; bptf: string; steamrep: string }): string {
+    return `🔍 ${name}'s info:\n[Steam Profile](${links.steam}) | [backpack.tf](${links.bptf}) | [steamREP](${links.steamrep})`;
 }
 
 function replaceItemName(name: string): string {

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -308,7 +308,7 @@ export = class MyHandler extends Handler {
 
             if (process.env.ENABLE_AUTOKEYS === 'true' && this.autokeys.isActive === true) {
                 log.debug('Disabling Autokeys and disabling key entry in the pricelist...');
-                this.autokeys.disable();
+                this.autokeys.disable(true);
             }
 
             this.bot.listings.removeAll().asCallback(err => {

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -2493,7 +2493,7 @@ export = class MyHandler extends Handler {
                         summarizeSteamChat(offer.summarize(this.bot.schema), value, keyPrices) +
                         (offerMessage.length !== 0 ? `\n\n💬 Offer message: "${offerMessage}"` : '') +
                         (list !== '-' ? `\n\nItem lists:\n${list}` : '') +
-                        `\n\nSteam: ${links.steamProfile}\nBackpack.tf: ${links.backpackTF}\nSteamREP: ${links.steamREP}` +
+                        `\n\nSteam: ${links.steam}\nBackpack.tf: ${links.bptf}\nSteamREP: ${links.steamrep}` +
                         `\n\n🔑 Key rate: ${keyPrices.buy.metal.toString()}/${keyPrices.sell.metal.toString()} ref` +
                         ` (${keyPrices.src === 'manual' ? 'manual' : 'prices.tf'})` +
                         `\n💰 Pure stock: ${pureStock.join(', ').toString()}` +
@@ -2982,11 +2982,11 @@ export = class MyHandler extends Handler {
         return { diff, diffRef, diffKey };
     }
 
-    tradePartnerLinks(steamID: string): { steamProfile: string; backpackTF: string; steamREP: string } {
+    tradePartnerLinks(steamID: string): { steam: string; bptf: string; steamrep: string } {
         const links = {
-            steamProfile: `https://steamcommunity.com/profiles/${steamID}`,
-            backpackTF: `https://backpack.tf/profiles/${steamID}`,
-            steamREP: `https://steamrep.com/profiles/${steamID}`
+            steam: `https://steamcommunity.com/profiles/${steamID}`,
+            bptf: `https://backpack.tf/profiles/${steamID}`,
+            steamrep: `https://steamrep.com/profiles/${steamID}`
         };
         return links;
     }

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -307,7 +307,7 @@ export = class MyHandler extends Handler {
             }
 
             if (process.env.ENABLE_AUTOKEYS === 'true' && this.autokeys.isActive === true) {
-                log.debug('Disabling Autokeys and removing key from pricelist...');
+                log.debug('Disabling Autokeys and disabling key entry in the pricelist...');
                 this.autokeys.disable();
             }
 

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -1772,7 +1772,7 @@ export = class MyHandler extends Handler {
                             .replace('Asked', '  My side')
                             .replace('Offered', 'Your side') +
                         "\n[You're missing: " +
-                        (value.diffRef > keyPrices.sell.toValue() ? `${value.diffKey}]` : `${value.diffRef} ref]`) +
+                        (value.diffRef > keyPrices.sell.metal ? `${value.diffKey}]` : `${value.diffRef} ref]`) +
                         `${
                             process.env.AUTO_DECLINE_INVALID_VALUE_NOTE
                                 ? '\n\nNote from owner: ' + process.env.AUTO_DECLINE_INVALID_VALUE_NOTE
@@ -2388,7 +2388,7 @@ export = class MyHandler extends Handler {
                 reviewReasons.push(note);
                 missingPureNote =
                     "\n[You're missing: " +
-                    (value.diffRef > keyPrices.sell.toValue() ? `${value.diffKey}]` : `${value.diffRef} ref]`);
+                    (value.diffRef > keyPrices.sell.metal ? `${value.diffKey}]` : `${value.diffRef} ref]`);
             }
 
             const highValueItems: string[] = [];

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -280,6 +280,8 @@ export default class Pricelist extends EventEmitter {
                     buy: entry.buy,
                     sell: entry.sell
                 };
+
+                log.debug('Autoprice key rate: ', this.globalKeyPrices);
             }
         }
 
@@ -299,6 +301,7 @@ export default class Pricelist extends EventEmitter {
                 src: 'manual',
                 time: null
             };
+            log.debug('New manually priced key rate: ', this.globalKeyPrices);
         }
     }
 

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -280,8 +280,6 @@ export default class Pricelist extends EventEmitter {
                     buy: entry.buy,
                     sell: entry.sell
                 };
-
-                log.debug('Autoprice key rate: ', this.globalKeyPrices);
             }
         }
 
@@ -301,7 +299,6 @@ export default class Pricelist extends EventEmitter {
                 src: 'manual',
                 time: null
             };
-            log.debug('New manually priced key rate: ', this.globalKeyPrices);
         }
     }
 

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -459,10 +459,10 @@ export default class Pricelist extends EventEmitter {
                 sell: new Currencies(keyPricesPTF.sell)
             };
 
-            const isEnabledScrapAdjustment =
-                process.env.ENABLE_AUTOKEYS === 'true' && process.env.DISABLE_SCRAP_ADJUSTMENT === 'false';
+            // const isEnabledScrapAdjustment =
+            //     process.env.ENABLE_AUTOKEYS === 'true' && process.env.DISABLE_SCRAP_ADJUSTMENT === 'false';
 
-            if (entryKey !== null && !entryKey.autoprice && !isEnabledScrapAdjustment) {
+            if (entryKey !== null && !entryKey.autoprice) {
                 this.globalKeyPrices = {
                     buy: entryKey.buy,
                     sell: entryKey.sell,

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -459,7 +459,10 @@ export default class Pricelist extends EventEmitter {
                 sell: new Currencies(keyPricesPTF.sell)
             };
 
-            if (entryKey !== null && !entryKey.autoprice) {
+            const isEnabledScrapAdjustment =
+                process.env.ENABLE_AUTOKEYS === 'true' && process.env.DISABLE_SCRAP_ADJUSTMENT === 'false';
+
+            if (entryKey !== null && !entryKey.autoprice && !isEnabledScrapAdjustment) {
                 this.globalKeyPrices = {
                     buy: entryKey.buy,
                     sell: entryKey.sell,

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -70,8 +70,6 @@ export class Entry {
         this.max = entry.max;
         this.min = entry.min;
         this.intent = entry.intent;
-        this.group = entry.group;
-        this.note = entry.note;
 
         // TODO: Validate entry
 

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -87,6 +87,18 @@ export class Entry {
             this.sell = null;
             this.time = null;
         }
+
+        if (entry.group) {
+            this.group = entry.group;
+        } else {
+            this.group = 'all';
+        }
+
+        if (entry.note) {
+            this.note = entry.note;
+        } else {
+            this.note = { buy: null, sell: null };
+        }
     }
 
     hasPrice(): boolean {

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -128,7 +128,9 @@ export default class Pricelist extends EventEmitter {
 
     private prices: Entry[] = [];
 
-    private keyPrices: { buy: Currencies; sell: Currencies; src: string; time: number };
+    private globalKeyPrices: { buy: Currencies; sell: Currencies; src: string; time: number };
+
+    private currentPTFKeyPrices: { buy: Currencies; sell: Currencies };
 
     // private priceChanges: {
     //     sku: string;
@@ -147,11 +149,11 @@ export default class Pricelist extends EventEmitter {
     }
 
     getKeyPrices(): { buy: Currencies; sell: Currencies; src: string; time: number } {
-        return this.keyPrices;
+        return this.globalKeyPrices;
     }
 
     getKeyPrice(): Currencies {
-        return this.keyPrices.sell;
+        return this.globalKeyPrices.sell;
     }
 
     getLength(): number {
@@ -267,11 +269,16 @@ export default class Pricelist extends EventEmitter {
             entry.time = pricePTF.time;
 
             if (entry.sku === '5021;6') {
-                this.keyPrices = {
+                this.globalKeyPrices = {
                     buy: entry.buy,
                     sell: entry.sell,
                     src: 'ptf',
                     time: entry.time
+                };
+
+                this.currentPTFKeyPrices = {
+                    buy: entry.buy,
+                    sell: entry.sell
                 };
             }
         }
@@ -286,7 +293,7 @@ export default class Pricelist extends EventEmitter {
 
         if (entry.sku === '5021;6' && !entry.autoprice && src === PricelistChangedSource.Command) {
             // update key rate if manually set the price
-            this.keyPrices = {
+            this.globalKeyPrices = {
                 buy: entry.buy,
                 sell: entry.sell,
                 src: 'manual',
@@ -447,22 +454,27 @@ export default class Pricelist extends EventEmitter {
             const entryKey = this.getPrice('5021;6', false);
             const timePTF = keyPricesPTF.time as number;
 
+            this.currentPTFKeyPrices = {
+                buy: new Currencies(keyPricesPTF.buy),
+                sell: new Currencies(keyPricesPTF.sell)
+            };
+
             if (entryKey !== null && !entryKey.autoprice) {
-                this.keyPrices = {
+                this.globalKeyPrices = {
                     buy: entryKey.buy,
                     sell: entryKey.sell,
                     src: 'manual',
                     time: entryKey.time
                 };
-                log.debug('Key rate is set based on current key prices in the pricelist.', this.keyPrices);
+                log.debug('Key rate is set based on current key prices in the pricelist.', this.globalKeyPrices);
             } else {
-                this.keyPrices = {
+                this.globalKeyPrices = {
                     buy: new Currencies(keyPricesPTF.buy),
                     sell: new Currencies(keyPricesPTF.sell),
                     src: 'ptf',
                     time: timePTF
                 };
-                log.debug('Key rate is set based current key prices.', this.keyPrices);
+                log.debug('Key rate is set based current key prices.', this.globalKeyPrices);
 
                 if (entryKey !== null && entryKey.autoprice) {
                     // The price of a key in the pricelist can be different from keyPrices because the pricelist is not updated
@@ -539,16 +551,38 @@ export default class Pricelist extends EventEmitter {
         const match = this.getPrice(data.sku);
 
         if (data.sku === '5021;6') {
-            if (match === null || (match !== null && match.autoprice)) {
+            const currentGlobalKeyBuyingPrice = this.globalKeyPrices.buy.metal;
+            const currentGlobalKeySellingPrice = this.globalKeyPrices.sell.metal;
+            const currentPTFBuyingPrice = this.currentPTFKeyPrices.buy.metal;
+            const currentPTFSellingPrice = this.currentPTFKeyPrices.sell.metal;
+
+            const isEnableScrapAdjustmentWithAutoprice =
+                process.env.ENABLE_AUTOKEYS === 'true' &&
+                process.env.DISABLE_SCRAP_ADJUSTMENT === 'false' &&
+                currentGlobalKeyBuyingPrice === currentPTFBuyingPrice &&
+                currentGlobalKeySellingPrice === currentPTFSellingPrice;
+
+            if (match === null || (match !== null && match.autoprice) || isEnableScrapAdjustmentWithAutoprice) {
                 // Only update global key rate if key is not in pricelist
                 // OR if exist, it's autoprice enabled (true)
-                this.keyPrices = {
+                // OR if Autokeys and Scrap Adjustment enabled, then check whether
+                // current global key rate are the same as current prices.tf key rate.
+                // if same, means autopriced and need to update to the latest price
+                // (and autokeys/scrap adjustment will update key prices after new trade).
+                // else entirely, key was manually priced and ignore updating global key rate.
+                this.globalKeyPrices = {
                     buy: new Currencies(data.buy),
                     sell: new Currencies(data.sell),
                     src: 'ptf',
                     time: data.time
                 };
             }
+
+            // currentPTFKeyPrices will still need to be updated.
+            this.currentPTFKeyPrices = {
+                buy: new Currencies(data.buy),
+                sell: new Currencies(data.sell)
+            };
         }
 
         if (match !== null && match.autoprice) {


### PR DESCRIPTION
**Fixes**
- fix incorrectly show the "You're missing: x" value.
- fix "❌ Failed to update pricelist entry: Cannot read property 'buy' of undefined" error (false report/log) when updating an item because the old pricelist entries don't have `group` and `note` properties - automatically add them to the pricelist entries.
- fix Autokeys - Scrap Adjustment (again) - accidentally set src for the global key rate to `manual` when it's actually autopriced when the bot restarted. The fix: [here](https://github.com/idinium96/tf2autobot/pull/139/commits/9c28b23bdb63ee73ff20647e3a7750c99a6cac8e#diff-9da9b4ea2f6674370e9023cfd18cfaa15f0a4f18b4103bd4ad94daa1b40cec53R1081-R1083).

**Changes/updates**
- #138 lowercase commands. `!heLp` and `!Help` will work now.
- clean codes in DiscordWebhook.ts.