### PR TITLE
Add item name matching on buy/sell, Add js-levenshtein library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2955,6 +2955,11 @@
             "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
             "dev": true
         },
+        "js-levenshtein": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+            "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
+        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "graceful-fs": "^4.2.4",
         "isobject": "^4.0.0",
         "jsonschema": "^1.4.0",
+        "js-levenshtein": "^1.1.6",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.32",
         "pjson": "^1.0.9",


### PR DESCRIPTION
This enhancement addresses #154 

**Note: Current implementation will find the nearest item by a distance of 3. This means that anything that is within 3 modifications of an item on the price-list will be found. This can be increased or decreased if it is shown to be too granular or not granular  enough.**

Below is an example of some example output from the current implementation of this feature:
![image](https://user-images.githubusercontent.com/5704760/99752531-80e57a00-2ab2-11eb-912e-d7d963bac197.png)
